### PR TITLE
fix: signature

### DIFF
--- a/src/client/lcd/Wallet.ts
+++ b/src/client/lcd/Wallet.ts
@@ -67,9 +67,7 @@ export class Wallet {
     let sequence = options.sequence;
 
     if (accountNumber === undefined || sequence === undefined) {
-      const res = await this.accountNumberAndSequence(
-        this.lcd.config[options.chainID].prefix
-      );
+      const res = await this.accountNumberAndSequence(options.chainID);
       if (accountNumber === undefined) {
         accountNumber = res.account_number;
       }


### PR DESCRIPTION
This pull request fixes the `createAndSignTx` method by sending the chainID a parameter instead of the prefix