### PR TITLE
Export mnemonic key options

### DIFF
--- a/src/key/MnemonicKey.ts
+++ b/src/key/MnemonicKey.ts
@@ -6,7 +6,7 @@ import { RawKey } from './RawKey';
 
 export const LUNA_COIN_TYPE = 330;
 
-interface MnemonicKeyOptions {
+export interface MnemonicKeyOptions {
   /**
    * Space-separated list of words for the mnemonic key.
    */


### PR DESCRIPTION
This interface should be exported in case the developers wants to abstract the LCD functionality in a single BlockchainService class 