### PR TITLE
Stride MsgLiquidStake and MsgRedeemStake

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@terra-money/feather.js",
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@terra-money/feather.js",
-      "version": "1.0.0-beta.11",
+      "version": "1.0.0-beta.12",
       "license": "MIT",
       "dependencies": {
         "@terra-money/legacy.proto": "npm:@terra-money/terra.proto@^0.1.7",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   },
   "dependencies": {
     "@terra-money/legacy.proto": "npm:@terra-money/terra.proto@^0.1.7",
-    "@terra-money/terra.proto": "^2.2.0-beta.3",
+    "@terra-money/terra.proto": "^2.2.0-beta.4",
     "axios": "^0.27.2",
     "bech32": "^2.0.0",
     "bip32": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/feather.js",
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.12",
   "description": "The JavaScript SDK for Terra and Feather chains",
   "license": "MIT",
   "author": "Terraform Labs, PTE.",

--- a/src/core/Msg.ts
+++ b/src/core/Msg.ts
@@ -86,6 +86,7 @@ import {
 } from './ibc/msgs/channel';
 import { MsgVerifyInvariant, CrisisMsg } from './crisis';
 import { Any } from '@terra-money/terra.proto/google/protobuf/any';
+import { MsgLiquidStake, MsgRedeemStake } from './stride/msgs';
 
 export type Msg =
   | BankMsg
@@ -102,6 +103,8 @@ export type Msg =
   | IbcConnectionMsg
   | IbcChannelMsg
   | AllianceMsg
+  | MsgLiquidStake
+  | MsgRedeemStake
   | CrisisMsg;
 
 export namespace Msg {
@@ -136,6 +139,8 @@ export namespace Msg {
     | AMsgDelegate.Data
     | AMsgRedelegate.Data
     | AMsgUndelegate.Data
+    | MsgLiquidStake.Data
+    | MsgRedeemStake.Data
     | CrisisMsg.Data;
 
   export type Proto =
@@ -156,6 +161,8 @@ export namespace Msg {
     | AMsgDelegate.Proto
     | AMsgRedelegate.Proto
     | AMsgUndelegate.Proto
+    | MsgLiquidStake.Proto
+    | MsgRedeemStake.Proto
     | CrisisMsg.Proto;
 
   export function fromAmino(data: Msg.Amino, isClassic?: boolean): Msg {
@@ -272,6 +279,10 @@ export namespace Msg {
   }
   export function fromData(data: Msg.Data, isClassic?: boolean): Msg {
     switch (data['@type']) {
+      case '/stride.stakeibc.MsgLiquidStake':
+        return MsgLiquidStake.fromData(data, isClassic);
+      case '/stride.stakeibc.MsgRedeemStake':
+        return MsgRedeemStake.fromData(data, isClassic);
       // alliance
       case '/alliance.alliance.MsgDelegate':
         return AMsgDelegate.fromData(data, isClassic);
@@ -424,6 +435,10 @@ export namespace Msg {
 
   export function fromProto(proto: Any, isClassic?: boolean): Msg {
     switch (proto.typeUrl) {
+      case '/stride.stakeibc.MsgLiquidStake':
+        return MsgLiquidStake.unpackAny(proto, isClassic);
+      case '/stride.stakeibc.MsgRedeemStake':
+        return MsgRedeemStake.unpackAny(proto, isClassic);
       // alliance
       case '/alliance.alliance.MsgDelegate':
         return AMsgDelegate.unpackAny(proto, isClassic);

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -14,6 +14,10 @@ export * from './Deposit';
 export * from './SignatureV2';
 export * from './MultiSignature';
 
+// Stride
+export { MsgLiquidStake } from './stride/msgs';
+export { MsgRedeemStake } from './stride/msgs';
+
 // Alliance
 export { MsgDelegate as MsgAllianceDelegate } from './alliance/msgs/MsgDelegate';
 export { MsgUndelegate as MsgAllianceUndelegate } from './alliance/msgs/MsgUndelegate';

--- a/src/core/stride/msgs/MsgLiquidStake.ts
+++ b/src/core/stride/msgs/MsgLiquidStake.ts
@@ -1,0 +1,88 @@
+import { JSONSerializable } from '../../../util/json';
+import { Any } from '@terra-money/terra.proto/google/protobuf/any';
+import { MsgLiquidStake as MsgLiquidStake_pb } from '@terra-money/terra.proto/build/stride/stakeibc/tx';
+
+// Used on Stride to create liquid staked asset from a native asset
+export class MsgLiquidStake extends JSONSerializable<
+  {},
+  MsgLiquidStake.Data,
+  MsgLiquidStake.Proto
+> {
+  /**
+   * @param creator the address of user who wants to create the staked assets
+   * @param amount amount of native assets to be staked
+   * @param hostDenom the denomination of the asset to be sent to delegate (uluna, uosmo...)
+   */
+  constructor(
+    public creator: string,
+    public amount: string,
+    public hostDenom: string
+  ) {
+    super();
+  }
+
+  public toAmino(_?: boolean): {} {
+    _;
+    throw Error(
+      'Legacy Amino not supported for MsgLiquidStake messages. Use Protobuf instead.'
+    );
+  }
+
+  public static fromProto(
+    proto: MsgLiquidStake.Proto,
+    _?: boolean
+  ): MsgLiquidStake {
+    _;
+    return new MsgLiquidStake(proto.creator, proto.amount, proto.hostDenom);
+  }
+
+  public toProto(_?: boolean): MsgLiquidStake.Proto {
+    _;
+    const { creator, amount, hostDenom } = this;
+    return MsgLiquidStake_pb.fromPartial({ creator, amount, hostDenom });
+  }
+
+  public packAny(_?: boolean): Any {
+    _;
+    return Any.fromPartial({
+      typeUrl: '/stride.stakeibc.MsgLiquidStake',
+      value: MsgLiquidStake_pb.encode(this.toProto()).finish(),
+    });
+  }
+
+  public static unpackAny(msgAny: Any, _?: boolean): MsgLiquidStake {
+    _;
+    return MsgLiquidStake.fromProto(MsgLiquidStake_pb.decode(msgAny.value));
+  }
+
+  public static fromData(
+    data: MsgLiquidStake.Data,
+    _?: boolean
+  ): MsgLiquidStake {
+    _;
+    const { creator, amount, hostDenom } = data;
+    return new MsgLiquidStake(creator, amount, hostDenom);
+  }
+
+  public toData(_?: boolean): MsgLiquidStake.Data {
+    _;
+    const { creator, amount, hostDenom } = this;
+    return {
+      '@type': '/stride.stakeibc.MsgLiquidStake',
+      creator,
+      amount,
+      hostDenom,
+    };
+  }
+}
+
+export namespace MsgLiquidStake {
+  export interface Data {
+    '@type': '/stride.stakeibc.MsgLiquidStake';
+    creator: string;
+    amount: string;
+    hostDenom: string;
+  }
+
+  export type Proto = MsgLiquidStake_pb;
+}

--- a/src/core/stride/msgs/MsgRedeemStake.ts
+++ b/src/core/stride/msgs/MsgRedeemStake.ts
@@ -1,0 +1,102 @@
+import { JSONSerializable } from '../../../util/json';
+import { Any } from '@terra-money/terra.proto/google/protobuf/any';
+import { MsgRedeemStake as MsgRedeemStake_pb } from '@terra-money/terra.proto/build/stride/stakeibc/tx';
+
+// Used on Stride to redeem the staked assets
+export class MsgRedeemStake extends JSONSerializable<
+  {},
+  MsgRedeemStake.Data,
+  MsgRedeemStake.Proto
+> {
+  /**
+   * @param creator the address of user who wants to redeem the staked assets
+   * @param amount amount of alliance assets to be sent for delegation
+   * @param hostZone the denomination of the asset to be sent to delegate
+   * @param receiver the address of user to receive the unstaked assets
+   */
+  constructor(
+    public creator: string,
+    public amount: string,
+    public hostZone: string,
+    public receiver: string
+  ) {
+    super();
+  }
+
+  public toAmino(_?: boolean): {} {
+    _;
+    throw Error(
+      'Legacy Amino not supported for MsgRedeemStake messages. Use Protobuf instead.'
+    );
+  }
+
+  public static fromProto(
+    proto: MsgRedeemStake.Proto,
+    _?: boolean
+  ): MsgRedeemStake {
+    _;
+    return new MsgRedeemStake(
+      proto.creator,
+      proto.amount,
+      proto.hostZone,
+      proto.receiver
+    );
+  }
+
+  public toProto(_?: boolean): MsgRedeemStake.Proto {
+    _;
+    const { creator, amount, hostZone, receiver } = this;
+    return MsgRedeemStake_pb.fromPartial({
+      creator,
+      amount,
+      hostZone,
+      receiver,
+    });
+  }
+
+  public packAny(_?: boolean): Any {
+    _;
+    return Any.fromPartial({
+      typeUrl: '/stride.stakeibc.MsgRedeemStake',
+      value: MsgRedeemStake_pb.encode(this.toProto()).finish(),
+    });
+  }
+
+  public static unpackAny(msgAny: Any, _?: boolean): MsgRedeemStake {
+    _;
+    return MsgRedeemStake.fromProto(MsgRedeemStake_pb.decode(msgAny.value));
+  }
+
+  public static fromData(
+    data: MsgRedeemStake.Data,
+    _?: boolean
+  ): MsgRedeemStake {
+    _;
+    const { creator, amount, hostZone, receiver } = data;
+    return new MsgRedeemStake(creator, amount, hostZone, receiver);
+  }
+
+  public toData(_?: boolean): MsgRedeemStake.Data {
+    _;
+    const { creator, amount, hostZone, receiver } = this;
+    return {
+      '@type': '/stride.stakeibc.MsgRedeemStake',
+      creator,
+      amount,
+      hostZone,
+      receiver,
+    };
+  }
+}
+
+export namespace MsgRedeemStake {
+  export interface Data {
+    '@type': '/stride.stakeibc.MsgRedeemStake';
+    creator: string;
+    amount: string;
+    hostZone: string;
+    receiver: string;
+  }
+
+  export type Proto = MsgRedeemStake_pb;
+}

--- a/src/core/stride/msgs/index.ts
+++ b/src/core/stride/msgs/index.ts
@@ -1,0 +1,2 @@
+export * from './MsgLiquidStake';
+export * from './MsgRedeemStake';


### PR DESCRIPTION
Basic Stride functionality to create an LSD from a native coin and redeem the native coin from the LSD. Code Example:

```ts
import { MsgLiquidStake, LCDClient, MnemonicKey, Wallet, isTxError } from "@terra-money/feather.js";

const lcd = new LCDClient({
    "stride-testnet-1": {
        "lcd": "https://stride.testnet-1.stridenet.co/api",
        "chainID": "stride-testnet-1",
        "gasAdjustment": 2,
        "gasPrices": {
            "ustrd": 0
        },
        "prefix": "stride",
    },
});
const acc = new MnemonicKey({
    mnemonic: "...",
    coinType: 118
});
const wallet = new Wallet(lcd, acc);

(async () => {
    const liquidStakeMsg = new MsgLiquidStake(
        "...",
        "100000",
        "uluna"
    );

    try {
        const lsdMsgTx = await wallet.createAndSignTx({
            msgs: [liquidStakeMsg],
            chainID: "stride-testnet-1",
        });
        const sendTxResult = await lcd.tx.broadcastAsync(lsdMsgTx, "stride-testnet-1");
        console.log(sendTxResult);
    } catch (e) {
        console.log(e);
    }
})();
```

Depends on https://github.com/terra-money/terra.proto/pull/21