### PR TITLE
Fix/cosmoskit ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 16
 
       - name: Use cached node_modules
         uses: actions/cache@v1

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 16
       - run: npm install
       - run: npm test
       - uses: JS-DevTools/npm-publish@v1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@terra-money/feather.js",
-  "version": "1.0.3",
+  "name": "@elix1er/feather.js",
+  "version": "1.0.3-pre",
   "description": "The JavaScript SDK for Terra and Feather chains",
   "license": "MIT",
   "author": "Terraform Labs, PTE.",
@@ -18,7 +18,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/terra-money/feather.js.git"
+    "url": "git://github.com/elix1er/feather.js.git"
   },
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@elix1er/feather.js",
-  "version": "1.0.3-pre",
+  "name": "@terra-money/feather.js",
+  "version": "1.0.4",
   "description": "The JavaScript SDK for Terra and Feather chains",
   "license": "MIT",
   "author": "Terraform Labs, PTE.",
@@ -18,7 +18,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/elix1er/feather.js.git"
+    "url": "git://github.com/terra-money/feather.js.git"
   },
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=16"
   },
   "scripts": {
     "build": "tsc --module commonjs && webpack --mode production",


### PR DESCRIPTION
revert to v16, as v18 not required
might fix breaking @cosmoskit/station-extension CI + avoids it's dependents being forced into using node v18