### PR TITLE
fix localterra prefix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@terra-money/feather.js",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@terra-money/feather.js",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@terra-money/legacy.proto": "npm:@terra-money/terra.proto@^0.1.7",

--- a/src/client/LocalTerra.ts
+++ b/src/client/LocalTerra.ts
@@ -49,7 +49,7 @@ export class LocalTerra extends LCDClient {
         chainID: 'localterra',
         gasAdjustment: 1.75,
         gasPrices: { uluna: 0.15 },
-        prefix: 'terra1',
+        prefix: 'terra',
       },
     });
 


### PR DESCRIPTION
localterra prefix is mistakenly spelled as `terra1`, when im testing terrain with feather.js I found it cannot wok with localterra, turns out the prefix hardcoded in feather.js for localterra is wrong.