### PR TITLE
feat: MsgTransfer with memo field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "webpack-cli": "^4.3.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=16"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@terra-money/feather.js",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@terra-money/feather.js",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "@terra-money/legacy.proto": "npm:@terra-money/terra.proto@^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/feather.js",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "The JavaScript SDK for Terra and Feather chains",
   "license": "MIT",
   "author": "Terraform Labs, PTE.",

--- a/src/core/ibc/applications/transfer/v1/msgs/MsgTransfer.spec.ts
+++ b/src/core/ibc/applications/transfer/v1/msgs/MsgTransfer.spec.ts
@@ -18,6 +18,7 @@ describe('MsgTransfer', () => {
           revision_height: '0',
         },
         timeout_timestamp: '1642663176848000000',
+        memo: 'memo',
       },
       true
     );
@@ -33,6 +34,7 @@ describe('MsgTransfer', () => {
         revision_height: 0,
       },
       timeout_timestamp: Numeric.parse('1642663176848000000'),
+      memo: 'memo',
     });
   });
 
@@ -46,6 +48,7 @@ describe('MsgTransfer', () => {
       receiver: 'recvr17lmam6zguazs5q5u6z5mmx76uj63gldnse2pdp',
       timeout_height: new Height(0, 0).toData(),
       timeout_timestamp: '1642663176848000000',
+      memo: 'memo',
     });
     const aminoSend = send.toAmino();
 
@@ -59,6 +62,7 @@ describe('MsgTransfer', () => {
         receiver: 'recvr17lmam6zguazs5q5u6z5mmx76uj63gldnse2pdp',
         timeout_height: {},
         timeout_timestamp: '1642663176848000000',
+        memo: 'memo',
       },
     });
 
@@ -78,6 +82,7 @@ describe('MsgTransfer', () => {
         revision_height: '57240001',
       },
       timeout_timestamp: '0',
+      memo: 'memo',
     });
     const aminoSend = send.toAmino();
 
@@ -91,6 +96,7 @@ describe('MsgTransfer', () => {
         receiver: 'recvr17lmam6zguazs5q5u6z5mmx76uj63gldnse2pdp',
         timeout_height: new Height(5, 57240001).toAmino(),
         timeout_timestamp: undefined,
+        memo: 'memo',
       },
     });
 

--- a/src/core/ibc/applications/transfer/v1/msgs/MsgTransfer.ts
+++ b/src/core/ibc/applications/transfer/v1/msgs/MsgTransfer.ts
@@ -21,6 +21,7 @@ export class MsgTransfer extends JSONSerializable<
   public receiver: string; // destination chain can be non-cosmos-based
   public timeout_height?: Height; // 0 to disable
   public timeout_timestamp?: Numeric.Output; // 0 to disable
+  public memo?: string;
   /**
    * @param source_port the port on which the packet will be sent
    * @param source_channel  the channel by which the packet will be sent
@@ -29,6 +30,7 @@ export class MsgTransfer extends JSONSerializable<
    * @param receiver the recipient address on the destination chain
    * @param timeout_height Timeout height relative to the current block height. (0 to disable)
    * @param timeout_timestamp Timeout timestamp (in nanoseconds) relative to the current block timestamp. (0 to disable)
+   * @param memo field can be used to send notes, interact with ibc-hooks, packet-middleware, etc...
    */
   constructor(
     source_port: string,
@@ -37,7 +39,8 @@ export class MsgTransfer extends JSONSerializable<
     sender: AccAddress,
     receiver: string,
     timeout_height: Height | undefined,
-    timeout_timestamp: Numeric.Input | undefined
+    timeout_timestamp: Numeric.Input | undefined,
+    memo: string | undefined
   ) {
     super();
 
@@ -54,6 +57,7 @@ export class MsgTransfer extends JSONSerializable<
     this.timeout_timestamp = timeout_timestamp
       ? Numeric.parse(timeout_timestamp)
       : undefined;
+    this.memo = memo;
   }
 
   public static fromAmino(data: MsgTransfer.Amino, _?: boolean): MsgTransfer {
@@ -67,6 +71,7 @@ export class MsgTransfer extends JSONSerializable<
         receiver,
         timeout_height,
         timeout_timestamp,
+        memo,
       },
     } = data;
 
@@ -81,7 +86,8 @@ export class MsgTransfer extends JSONSerializable<
       sender,
       receiver,
       timeout_height ? Height.fromAmino(timeout_height) : undefined,
-      timeout_timestamp ? Numeric.parse(timeout_timestamp) : undefined
+      timeout_timestamp ? Numeric.parse(timeout_timestamp) : undefined,
+      memo
     );
   }
 
@@ -95,6 +101,7 @@ export class MsgTransfer extends JSONSerializable<
       receiver,
       timeout_height,
       timeout_timestamp,
+      memo,
     } = this;
     return {
       type: 'cosmos-sdk/MsgTransfer',
@@ -106,6 +113,7 @@ export class MsgTransfer extends JSONSerializable<
         receiver,
         timeout_height: timeout_height?.toAmino() || {},
         timeout_timestamp: timeout_timestamp?.toFixed() || undefined,
+        memo,
       },
     };
   }
@@ -120,6 +128,7 @@ export class MsgTransfer extends JSONSerializable<
       receiver,
       timeout_timestamp,
       timeout_height,
+      memo,
     } = data;
 
     if (!timeout_height && !timeout_timestamp) {
@@ -133,7 +142,8 @@ export class MsgTransfer extends JSONSerializable<
       sender,
       receiver,
       timeout_height ? Height.fromData(timeout_height) : undefined,
-      timeout_timestamp ? Number.parseInt(timeout_timestamp) : undefined
+      timeout_timestamp ? Number.parseInt(timeout_timestamp) : undefined,
+      memo
     );
   }
 
@@ -147,6 +157,7 @@ export class MsgTransfer extends JSONSerializable<
       receiver,
       timeout_height,
       timeout_timestamp,
+      memo,
     } = this;
     return {
       '@type': '/ibc.applications.transfer.v1.MsgTransfer',
@@ -159,6 +170,7 @@ export class MsgTransfer extends JSONSerializable<
         ? timeout_height.toData()
         : new Height(0, 0).toData(),
       timeout_timestamp: timeout_timestamp?.toFixed() || '0',
+      memo,
     };
   }
 
@@ -175,7 +187,8 @@ export class MsgTransfer extends JSONSerializable<
       proto.sender,
       proto.receiver,
       proto.timeoutHeight ? Height.fromProto(proto.timeoutHeight) : undefined,
-      proto.timeoutTimestamp.toNumber()
+      proto.timeoutTimestamp.toNumber(),
+      proto.memo
     );
   }
 
@@ -189,6 +202,7 @@ export class MsgTransfer extends JSONSerializable<
       receiver,
       timeout_height,
       timeout_timestamp,
+      memo,
     } = this;
     return MsgTransfer_pb.fromPartial({
       sourcePort: source_port,
@@ -198,6 +212,7 @@ export class MsgTransfer extends JSONSerializable<
       receiver,
       timeoutHeight: timeout_height ? timeout_height.toProto() : undefined,
       timeoutTimestamp: Long.fromString(timeout_timestamp?.toFixed() || '0'),
+      memo,
     });
   }
 
@@ -227,6 +242,7 @@ export namespace MsgTransfer {
       receiver: string;
       timeout_height: Height.Amino;
       timeout_timestamp?: string;
+      memo?: string;
     };
   }
   export interface Data {
@@ -238,6 +254,7 @@ export namespace MsgTransfer {
     receiver: string;
     timeout_height: Height.Data;
     timeout_timestamp: string;
+    memo?: string;
   }
   export type Proto = MsgTransfer_pb;
 }


### PR DESCRIPTION
Memo field was missing from MsgTransfer. The field is useful to send notes, interact with ibc-hooks, packet-middleware, etc... 