### PR TITLE
Classic: Parity of Smart Contract Messages

### DIFF
--- a/src/core/wasm/msgs/MsgClearContractAdmin.ts
+++ b/src/core/wasm/msgs/MsgClearContractAdmin.ts
@@ -19,132 +19,74 @@ export class MsgClearContractAdmin extends JSONSerializable<
 
   public static fromAmino(
     data: MsgClearContractAdmin.Amino,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): MsgClearContractAdmin {
-    if (isClassic) {
-      const {
-        value: { admin, contract },
-      } = data as MsgClearContractAdmin.AminoV1;
-      return new MsgClearContractAdmin(admin, contract);
-    } else {
-      const {
-        value: { sender, contract },
-      } = data as MsgClearContractAdmin.AminoV2;
-      return new MsgClearContractAdmin(sender, contract);
-    }
+    const {
+      value: { sender, contract },
+    } = data as MsgClearContractAdmin.AminoV2;
+    return new MsgClearContractAdmin(sender, contract);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public toAmino(isClassic?: boolean): MsgClearContractAdmin.Amino {
+  public toAmino(_isClassic?: boolean): MsgClearContractAdmin.Amino {
     const { admin, contract } = this;
-    if (isClassic) {
-      return {
-        type: 'wasm/MsgClearContractAdmin',
-        value: {
-          admin,
-          contract,
-        },
-      };
-    } else {
-      return {
-        type: 'wasm/MsgClearAdmin',
-        value: {
-          sender: admin,
-          contract,
-        },
-      };
-    }
+    return {
+      type: 'wasm/MsgClearAdmin',
+      value: {
+        sender: admin,
+        contract,
+      },
+    };
   }
 
   public static fromProto(
     data: MsgClearContractAdmin.Proto,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): MsgClearContractAdmin {
-    if (isClassic) {
-      const { admin, contract } = data as MsgClearContractAdmin.DataV1;
-      return new MsgClearContractAdmin(admin, contract);
-    } else {
-      const { sender, contract } = data as MsgClearContractAdmin.DataV2;
-      return new MsgClearContractAdmin(sender, contract);
-    }
+    const { sender, contract } = data as MsgClearContractAdmin.DataV2;
+    return new MsgClearContractAdmin(sender, contract);
   }
 
-  public toProto(isClassic?: boolean): MsgClearContractAdmin.Proto {
-    if (isClassic) {
-      return MsgClearContractAdmin_legacy_pb.fromPartial({
-        admin: this.admin,
-        contract: this.contract,
-      });
-    } else {
-      return MsgClearAdmin_pb.fromPartial({
-        sender: this.admin,
-        contract: this.contract,
-      });
-    }
+  public toProto(_isClassic?: boolean): MsgClearContractAdmin.Proto {
+    return MsgClearAdmin_pb.fromPartial({
+      sender: this.admin,
+      contract: this.contract,
+    });
   }
 
   public packAny(isClassic?: boolean): Any {
-    if (isClassic) {
-      return Any.fromPartial({
-        typeUrl: '/terra.wasm.v1beta1.MsgClearContractAdmin',
-        value: MsgClearContractAdmin_legacy_pb.encode(
-          this.toProto(isClassic) as MsgClearContractAdmin_legacy_pb
-        ).finish(),
-      });
-    } else {
-      return Any.fromPartial({
-        typeUrl: '/cosmwasm.wasm.v1.MsgClearAdmin',
-        value: MsgClearAdmin_pb.encode(
-          this.toProto(isClassic) as MsgClearAdmin_pb
-        ).finish(),
-      });
-    }
+    return Any.fromPartial({
+      typeUrl: '/cosmwasm.wasm.v1.MsgClearAdmin',
+      value: MsgClearAdmin_pb.encode(
+        this.toProto(isClassic) as MsgClearAdmin_pb
+      ).finish(),
+    });
   }
 
   public static unpackAny(
     msgAny: Any,
     isClassic?: boolean
   ): MsgClearContractAdmin {
-    if (isClassic) {
-      return MsgClearContractAdmin.fromProto(
-        MsgClearContractAdmin_legacy_pb.decode(msgAny.value),
-        isClassic
-      );
-    } else {
-      return MsgClearContractAdmin.fromProto(
-        MsgClearAdmin_pb.decode(msgAny.value),
-        isClassic
-      );
-    }
+    return MsgClearContractAdmin.fromProto(
+      MsgClearAdmin_pb.decode(msgAny.value),
+      isClassic
+    );
   }
 
   public static fromData(
     data: MsgClearContractAdmin.Data,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): MsgClearContractAdmin {
-    if (isClassic) {
-      const { admin, contract } = data as MsgClearContractAdmin.DataV1;
-      return new MsgClearContractAdmin(admin, contract);
-    } else {
-      const { sender, contract } = data as MsgClearContractAdmin.DataV2;
-      return new MsgClearContractAdmin(sender, contract);
-    }
+    const { sender, contract } = data as MsgClearContractAdmin.DataV2;
+    return new MsgClearContractAdmin(sender, contract);
   }
 
-  public toData(isClassic?: boolean): MsgClearContractAdmin.Data {
-    if (isClassic) {
-      return {
-        '@type': '/terra.wasm.v1beta1.MsgClearContractAdmin',
-        admin: this.admin,
-        contract: this.contract,
-      };
-    } else {
-      return {
-        '@type': '/cosmwasm.wasm.v1.MsgClearAdmin',
-        sender: this.admin,
-        contract: this.contract,
-      };
-    }
+  public toData(_isClassic?: boolean): MsgClearContractAdmin.Data {
+    return {
+      '@type': '/cosmwasm.wasm.v1.MsgClearAdmin',
+      sender: this.admin,
+      contract: this.contract,
+    };
   }
 }
 

--- a/src/core/wasm/msgs/MsgClearContractAdmin.ts
+++ b/src/core/wasm/msgs/MsgClearContractAdmin.ts
@@ -19,7 +19,7 @@ export class MsgClearContractAdmin extends JSONSerializable<
 
   public static fromAmino(
     data: MsgClearContractAdmin.Amino,
-    _isClassic?: boolean
+    _?: boolean
   ): MsgClearContractAdmin {
     const {
       value: { sender, contract },
@@ -28,7 +28,7 @@ export class MsgClearContractAdmin extends JSONSerializable<
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public toAmino(_isClassic?: boolean): MsgClearContractAdmin.Amino {
+  public toAmino(_?: boolean): MsgClearContractAdmin.Amino {
     const { admin, contract } = this;
     return {
       type: 'wasm/MsgClearAdmin',
@@ -41,13 +41,13 @@ export class MsgClearContractAdmin extends JSONSerializable<
 
   public static fromProto(
     data: MsgClearContractAdmin.Proto,
-    _isClassic?: boolean
+    _?: boolean
   ): MsgClearContractAdmin {
     const { sender, contract } = data as MsgClearContractAdmin.DataV2;
     return new MsgClearContractAdmin(sender, contract);
   }
 
-  public toProto(_isClassic?: boolean): MsgClearContractAdmin.Proto {
+  public toProto(_?: boolean): MsgClearContractAdmin.Proto {
     return MsgClearAdmin_pb.fromPartial({
       sender: this.admin,
       contract: this.contract,
@@ -75,13 +75,13 @@ export class MsgClearContractAdmin extends JSONSerializable<
 
   public static fromData(
     data: MsgClearContractAdmin.Data,
-    _isClassic?: boolean
+    _?: boolean
   ): MsgClearContractAdmin {
     const { sender, contract } = data as MsgClearContractAdmin.DataV2;
     return new MsgClearContractAdmin(sender, contract);
   }
 
-  public toData(_isClassic?: boolean): MsgClearContractAdmin.Data {
+  public toData(_?: boolean): MsgClearContractAdmin.Data {
     return {
       '@type': '/cosmwasm.wasm.v1.MsgClearAdmin',
       sender: this.admin,

--- a/src/core/wasm/msgs/MsgExecuteContract.spec.ts
+++ b/src/core/wasm/msgs/MsgExecuteContract.spec.ts
@@ -3,67 +3,24 @@ import { MsgExecuteContract as MsgExecuteContract_legacy_pb } from '@terra-money
 import { MsgExecuteContract as MsgExecuteContract_pb } from '@terra-money/terra.proto/cosmwasm/wasm/v1/tx';
 
 describe('MsgExecuteContract', () => {
-  it('legacy: works when execute_msg is not JSON', () => {
-    const msg1 = MsgExecuteContract.fromAmino({
-      type: 'wasm/MsgExecuteContract',
-      value: {
-        sender: 'terra16xw94u0jgmuaz8zs54xn9x96lxew74gs05gs4h',
-        contract: 'terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6',
-        execute_msg: {
-          transfer: {
-            recipient: 'terra13jqgrtqwucx4jdvhg0d4tc80892fscx54298yt',
-            amount: 10000,
-          },
-        },
-        coins: [],
-      },
-    }, true);
-
-    expect(msg1.execute_msg).toMatchObject({
-      transfer: {
-        recipient: 'terra13jqgrtqwucx4jdvhg0d4tc80892fscx54298yt',
-        amount: 10000,
-      },
-    });
-  });
-
   it('works when execute_msg is not JSON', () => {
-    const msg1 = MsgExecuteContract.fromAmino({
-      type: 'wasm/MsgExecuteContract',
-      value: {
-        sender: 'terra16xw94u0jgmuaz8zs54xn9x96lxew74gs05gs4h',
-        contract: 'terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6',
-        msg: {
-          transfer: {
-            recipient: 'terra13jqgrtqwucx4jdvhg0d4tc80892fscx54298yt',
-            amount: 10000,
+    const msg1 = MsgExecuteContract.fromAmino(
+      {
+        type: 'wasm/MsgExecuteContract',
+        value: {
+          sender: 'terra16xw94u0jgmuaz8zs54xn9x96lxew74gs05gs4h',
+          contract: 'terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6',
+          msg: {
+            transfer: {
+              recipient: 'terra13jqgrtqwucx4jdvhg0d4tc80892fscx54298yt',
+              amount: 10000,
+            },
           },
-        },
-        funds: [],
-      },
-    }, false);
-
-    expect(msg1.execute_msg).toMatchObject({
-      transfer: {
-        recipient: 'terra13jqgrtqwucx4jdvhg0d4tc80892fscx54298yt',
-        amount: 10000,
-      },
-    });
-  });
-
-  it('legacy proto', () => {
-    const msg1 = MsgExecuteContract.fromData({
-      '@type': '/terra.wasm.v1beta1.MsgExecuteContract',
-      sender: 'terra16xw94u0jgmuaz8zs54xn9x96lxew74gs05gs4h',
-      contract: 'terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6',
-      execute_msg: {
-        transfer: {
-          recipient: 'terra13jqgrtqwucx4jdvhg0d4tc80892fscx54298yt',
-          amount: 10000,
+          funds: [],
         },
       },
-      coins: [],
-    }, true);
+      false
+    );
 
     expect(msg1.execute_msg).toMatchObject({
       transfer: {
@@ -74,18 +31,21 @@ describe('MsgExecuteContract', () => {
   });
 
   it('proto', () => {
-    const msg1 = MsgExecuteContract.fromData({
-      '@type': '/cosmwasm.wasm.v1.MsgExecuteContract',
-      sender: 'terra16xw94u0jgmuaz8zs54xn9x96lxew74gs05gs4h',
-      contract: 'terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6',
-      msg: {
-        transfer: {
-          recipient: 'terra13jqgrtqwucx4jdvhg0d4tc80892fscx54298yt',
-          amount: 10000,
+    const msg1 = MsgExecuteContract.fromData(
+      {
+        '@type': '/cosmwasm.wasm.v1.MsgExecuteContract',
+        sender: 'terra16xw94u0jgmuaz8zs54xn9x96lxew74gs05gs4h',
+        contract: 'terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6',
+        msg: {
+          transfer: {
+            recipient: 'terra13jqgrtqwucx4jdvhg0d4tc80892fscx54298yt',
+            amount: 10000,
+          },
         },
+        funds: [],
       },
-      funds: [],
-    }, false);
+      false
+    );
 
     expect(msg1.execute_msg).toMatchObject({
       transfer: {
@@ -95,29 +55,6 @@ describe('MsgExecuteContract', () => {
     });
   });
 
-
-
-  it('legacy: with string msg', () => {
-    const msgWithExecuteString = new MsgExecuteContract(
-      'terra1x46rqay4d3cssq8gxxvqz8xt6nwlz4td20k38v',
-      'terra1x46rqay4d3cssq8gxxvqz8xt6nwlz4td20k38v',
-      'execute_msg_as_string',
-      { uluna: 120400 }
-    );
-    const aminoWithExecuteString = msgWithExecuteString.toAmino(true) as MsgExecuteContract.AminoV1;
-    expect(aminoWithExecuteString.value.execute_msg).toEqual(
-      msgWithExecuteString.execute_msg
-    );
-    const protoWithExecuteString = msgWithExecuteString.toProto(true) as MsgExecuteContract_legacy_pb;
-    expect(protoWithExecuteString.executeMsg.toString()).toEqual(
-      JSON.stringify(msgWithExecuteString.execute_msg)
-    );
-    const dataWithExecuteString = msgWithExecuteString.toData(true) as MsgExecuteContract.DataV1;
-    expect(dataWithExecuteString.execute_msg).toEqual(
-      msgWithExecuteString.execute_msg
-    );
-  });
-
   it('with string msg', () => {
     const msgWithExecuteString = new MsgExecuteContract(
       'terra1x46rqay4d3cssq8gxxvqz8xt6nwlz4td20k38v',
@@ -125,19 +62,21 @@ describe('MsgExecuteContract', () => {
       'execute_msg_as_string',
       { uluna: 120400 }
     );
-    const aminoWithExecuteString = msgWithExecuteString.toAmino(false) as MsgExecuteContract.AminoV2;
+    const aminoWithExecuteString = msgWithExecuteString.toAmino(
+      false
+    ) as MsgExecuteContract.AminoV2;
     expect(aminoWithExecuteString.value.msg).toEqual(
       msgWithExecuteString.execute_msg
     );
-    const protoWithExecuteString = msgWithExecuteString.toProto(false) as MsgExecuteContract_pb;
+    const protoWithExecuteString = msgWithExecuteString.toProto(
+      false
+    ) as MsgExecuteContract_pb;
     expect(protoWithExecuteString.msg.toString()).toEqual(
       JSON.stringify(msgWithExecuteString.execute_msg)
     );
-    const dataWithExecuteString = msgWithExecuteString.toData(false) as MsgExecuteContract.DataV2;
-    expect(dataWithExecuteString.msg).toEqual(
-      msgWithExecuteString.execute_msg
-    );
+    const dataWithExecuteString = msgWithExecuteString.toData(
+      false
+    ) as MsgExecuteContract.DataV2;
+    expect(dataWithExecuteString.msg).toEqual(msgWithExecuteString.execute_msg);
   });
-
-
 });

--- a/src/core/wasm/msgs/MsgExecuteContract.ts
+++ b/src/core/wasm/msgs/MsgExecuteContract.ts
@@ -30,117 +30,62 @@ export class MsgExecuteContract extends JSONSerializable<
 
   public static fromAmino(
     data: MsgExecuteContract.Amino,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): MsgExecuteContract {
-    if (isClassic) {
-      const {
-        value: { sender, contract, execute_msg, coins },
-      } = data as MsgExecuteContract.AminoV1;
-      return new MsgExecuteContract(
-        sender,
-        contract,
-        execute_msg,
-        Coins.fromAmino(coins)
-      );
-    } else {
-      const {
-        value: { sender, contract, msg, funds },
-      } = data as MsgExecuteContract.AminoV2;
-      return new MsgExecuteContract(
-        sender,
-        contract,
-        msg,
-        Coins.fromAmino(funds)
-      );
-    }
+    const {
+      value: { sender, contract, msg, funds },
+    } = data as MsgExecuteContract.AminoV2;
+    return new MsgExecuteContract(
+      sender,
+      contract,
+      msg,
+      Coins.fromAmino(funds)
+    );
   }
 
-  public toAmino(isClassic?: boolean): MsgExecuteContract.Amino {
+  public toAmino(_isClassic?: boolean): MsgExecuteContract.Amino {
     const { sender, contract, execute_msg, coins } = this;
-    if (isClassic) {
-      return {
-        type: 'wasm/MsgExecuteContract',
-        value: {
-          sender,
-          contract,
-          execute_msg: removeNull(execute_msg),
-          coins: coins.toAmino(),
-        },
-      };
-    } else {
-      return {
-        type: 'wasm/MsgExecuteContract',
-        value: {
-          sender,
-          contract,
-          msg: removeNull(execute_msg),
-          funds: coins.toAmino(),
-        },
-      };
-    }
+    return {
+      type: 'wasm/MsgExecuteContract',
+      value: {
+        sender,
+        contract,
+        msg: removeNull(execute_msg),
+        funds: coins.toAmino(),
+      },
+    };
   }
 
   public static fromProto(
     proto: MsgExecuteContract.Proto,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): MsgExecuteContract {
-    if (isClassic) {
-      const p = proto as MsgExecuteContract_legacy_pb;
-      return new MsgExecuteContract(
-        p.sender,
-        p.contract,
-        JSON.parse(Buffer.from(p.executeMsg).toString('utf-8')),
-        Coins.fromProto(p.coins)
-      );
-    } else {
-      const p = proto as MsgExecuteContract_pb;
-      return new MsgExecuteContract(
-        p.sender,
-        p.contract,
-        JSON.parse(Buffer.from(p.msg).toString('utf-8')),
-        Coins.fromProto(p.funds)
-      );
-    }
+    const p = proto as MsgExecuteContract_pb;
+    return new MsgExecuteContract(
+      p.sender,
+      p.contract,
+      JSON.parse(Buffer.from(p.msg).toString('utf-8')),
+      Coins.fromProto(p.funds)
+    );
   }
 
-  public toProto(isClassic?: boolean): MsgExecuteContract.Proto {
+  public toProto(_isClassic?: boolean): MsgExecuteContract.Proto {
     const { sender, contract, execute_msg, coins } = this;
-    if (isClassic) {
-      return MsgExecuteContract_legacy_pb.fromPartial({
-        coins: coins.toProto(),
-        contract,
-        sender,
-        executeMsg: Buffer.from(
-          JSON.stringify(removeNull(execute_msg)),
-          'utf-8'
-        ),
-      });
-    } else {
-      return MsgExecuteContract_pb.fromPartial({
-        funds: coins.toProto(),
-        contract,
-        sender,
-        msg: Buffer.from(JSON.stringify(removeNull(execute_msg)), 'utf-8'),
-      });
-    }
+    return MsgExecuteContract_pb.fromPartial({
+      funds: coins.toProto(),
+      contract,
+      sender,
+      msg: Buffer.from(JSON.stringify(removeNull(execute_msg)), 'utf-8'),
+    });
   }
 
   public packAny(isClassic?: boolean): Any {
-    if (isClassic) {
-      return Any.fromPartial({
-        typeUrl: '/terra.wasm.v1beta1.MsgExecuteContract',
-        value: MsgExecuteContract_legacy_pb.encode(
-          this.toProto(isClassic) as MsgExecuteContract_legacy_pb
-        ).finish(),
-      });
-    } else {
-      return Any.fromPartial({
-        typeUrl: '/cosmwasm.wasm.v1.MsgExecuteContract',
-        value: MsgExecuteContract_pb.encode(
-          this.toProto(isClassic) as MsgExecuteContract_pb
-        ).finish(),
-      });
-    }
+    return Any.fromPartial({
+      typeUrl: '/cosmwasm.wasm.v1.MsgExecuteContract',
+      value: MsgExecuteContract_pb.encode(
+        this.toProto(isClassic) as MsgExecuteContract_pb
+      ).finish(),
+    });
   }
 
   public static unpackAny(
@@ -148,57 +93,28 @@ export class MsgExecuteContract extends JSONSerializable<
     isClassic?: boolean
   ): MsgExecuteContract {
     return MsgExecuteContract.fromProto(
-      isClassic
-        ? MsgExecuteContract_legacy_pb.decode(msgAny.value)
-        : MsgExecuteContract_pb.decode(msgAny.value),
+      MsgExecuteContract_pb.decode(msgAny.value),
       isClassic
     );
   }
 
   public static fromData(
     data: MsgExecuteContract.Data,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): MsgExecuteContract {
-    if (isClassic) {
-      const { sender, contract, execute_msg, coins } =
-        data as MsgExecuteContract.DataV1;
-      return new MsgExecuteContract(
-        sender,
-        contract,
-        execute_msg,
-        Coins.fromData(coins)
-      );
-    } else {
-      const { sender, contract, msg, funds } =
-        data as MsgExecuteContract.DataV2;
-      return new MsgExecuteContract(
-        sender,
-        contract,
-        msg,
-        Coins.fromData(funds)
-      );
-    }
+    const { sender, contract, msg, funds } = data as MsgExecuteContract.DataV2;
+    return new MsgExecuteContract(sender, contract, msg, Coins.fromData(funds));
   }
 
-  public toData(isClassic?: boolean): MsgExecuteContract.Data {
+  public toData(_isClassic?: boolean): MsgExecuteContract.Data {
     const { sender, contract, execute_msg, coins } = this;
-    if (isClassic) {
-      return {
-        '@type': '/terra.wasm.v1beta1.MsgExecuteContract',
-        sender,
-        contract,
-        execute_msg,
-        coins: coins.toData(),
-      };
-    } else {
-      return {
-        '@type': '/cosmwasm.wasm.v1.MsgExecuteContract',
-        sender,
-        contract,
-        msg: execute_msg,
-        funds: coins.toData(),
-      };
-    }
+    return {
+      '@type': '/cosmwasm.wasm.v1.MsgExecuteContract',
+      sender,
+      contract,
+      msg: execute_msg,
+      funds: coins.toData(),
+    };
   }
 }
 

--- a/src/core/wasm/msgs/MsgExecuteContract.ts
+++ b/src/core/wasm/msgs/MsgExecuteContract.ts
@@ -30,7 +30,7 @@ export class MsgExecuteContract extends JSONSerializable<
 
   public static fromAmino(
     data: MsgExecuteContract.Amino,
-    _isClassic?: boolean
+    _?: boolean
   ): MsgExecuteContract {
     const {
       value: { sender, contract, msg, funds },
@@ -43,7 +43,7 @@ export class MsgExecuteContract extends JSONSerializable<
     );
   }
 
-  public toAmino(_isClassic?: boolean): MsgExecuteContract.Amino {
+  public toAmino(_?: boolean): MsgExecuteContract.Amino {
     const { sender, contract, execute_msg, coins } = this;
     return {
       type: 'wasm/MsgExecuteContract',
@@ -58,7 +58,7 @@ export class MsgExecuteContract extends JSONSerializable<
 
   public static fromProto(
     proto: MsgExecuteContract.Proto,
-    _isClassic?: boolean
+    _?: boolean
   ): MsgExecuteContract {
     const p = proto as MsgExecuteContract_pb;
     return new MsgExecuteContract(
@@ -69,7 +69,7 @@ export class MsgExecuteContract extends JSONSerializable<
     );
   }
 
-  public toProto(_isClassic?: boolean): MsgExecuteContract.Proto {
+  public toProto(_?: boolean): MsgExecuteContract.Proto {
     const { sender, contract, execute_msg, coins } = this;
     return MsgExecuteContract_pb.fromPartial({
       funds: coins.toProto(),
@@ -100,13 +100,13 @@ export class MsgExecuteContract extends JSONSerializable<
 
   public static fromData(
     data: MsgExecuteContract.Data,
-    _isClassic?: boolean
+    _?: boolean
   ): MsgExecuteContract {
     const { sender, contract, msg, funds } = data as MsgExecuteContract.DataV2;
     return new MsgExecuteContract(sender, contract, msg, Coins.fromData(funds));
   }
 
-  public toData(_isClassic?: boolean): MsgExecuteContract.Data {
+  public toData(_?: boolean): MsgExecuteContract.Data {
     const { sender, contract, execute_msg, coins } = this;
     return {
       '@type': '/cosmwasm.wasm.v1.MsgExecuteContract',

--- a/src/core/wasm/msgs/MsgInstantiateContract.spec.ts
+++ b/src/core/wasm/msgs/MsgInstantiateContract.spec.ts
@@ -27,19 +27,6 @@ const msgWithInitString = new MsgInstantiateContract(
 );
 
 describe('MsgInstantiateContract', () => {
-  it('legacy amino', () => {
-    const aminoWithAdmin = msgWithAdmin.toAmino(true);
-    expect(aminoWithAdmin.value.admin).toEqual(msgWithAdmin.admin);
-
-    const aminoWithoutAdmin = msgWithoutAdmin.toAmino(true);
-    expect(aminoWithoutAdmin.value.admin).toEqual(msgWithoutAdmin.admin);
-
-    const aminoWithInitString = msgWithInitString.toAmino(true) as MsgInstantiateContract.AminoV1;
-    expect(aminoWithInitString.value.init_msg).toEqual(
-      msgWithInitString.init_msg
-    );
-  });
-
   it('amino', () => {
     const aminoWithAdmin = msgWithAdmin.toAmino(false);
     expect(aminoWithAdmin.value.admin).toEqual(msgWithAdmin.admin);
@@ -47,23 +34,10 @@ describe('MsgInstantiateContract', () => {
     const aminoWithoutAdmin = msgWithoutAdmin.toAmino(false);
     expect(aminoWithoutAdmin.value.admin).toEqual(msgWithoutAdmin.admin);
 
-    const aminoWithInitString = msgWithInitString.toAmino(false) as MsgInstantiateContract.AminoV2;
-    expect(aminoWithInitString.value.msg).toEqual(
-      msgWithInitString.init_msg
-    );
-  });
-
-  it('legacy proto', () => {
-    const protoWithAdmin = msgWithAdmin.toProto(true);
-    expect(protoWithAdmin.admin).toEqual(msgWithAdmin.admin);
-
-    const protoWithoutAdmin = msgWithoutAdmin.toProto(true);
-    expect(protoWithoutAdmin.admin).toEqual('');
-
-    const protoWithInitString = msgWithInitString.toProto(true) as MsgInstantiateContract_legacy_pb;
-    expect(protoWithInitString.initMsg.toString()).toEqual(
-      JSON.stringify(msgWithInitString.init_msg)
-    );
+    const aminoWithInitString = msgWithInitString.toAmino(
+      false
+    ) as MsgInstantiateContract.AminoV2;
+    expect(aminoWithInitString.value.msg).toEqual(msgWithInitString.init_msg);
   });
 
   it('proto', () => {
@@ -73,22 +47,11 @@ describe('MsgInstantiateContract', () => {
     const protoWithoutAdmin = msgWithoutAdmin.toProto();
     expect(protoWithoutAdmin.admin).toEqual('');
 
-    const protoWithInitString = msgWithInitString.toProto() as MsgInstantiateContract_pb;
+    const protoWithInitString =
+      msgWithInitString.toProto() as MsgInstantiateContract_pb;
     expect(protoWithInitString.msg.toString()).toEqual(
       JSON.stringify(msgWithInitString.init_msg)
     );
-  });
-
-
-  it('legacy data', () => {
-    const dataWithAdmin = msgWithAdmin.toData(true);
-    expect(dataWithAdmin.admin).toEqual(msgWithAdmin.admin);
-
-    const dataWithoutAdmin = msgWithoutAdmin.toData(true);
-    expect(dataWithoutAdmin.admin).toEqual('');
-
-    const dataWithInitString = msgWithInitString.toData(true) as MsgInstantiateContract.DataV1;
-    expect(dataWithInitString.init_msg).toEqual(msgWithInitString.init_msg);
   });
 
   it('data', () => {
@@ -98,7 +61,9 @@ describe('MsgInstantiateContract', () => {
     const dataWithoutAdmin2 = msgWithoutAdmin.toData(false);
     expect(dataWithoutAdmin2.admin).toEqual('');
 
-    const dataWithInitString2 = msgWithInitString.toData(false) as MsgInstantiateContract.DataV2;
+    const dataWithInitString2 = msgWithInitString.toData(
+      false
+    ) as MsgInstantiateContract.DataV2;
     expect(dataWithInitString2.msg).toEqual(msgWithInitString.init_msg);
   });
 });

--- a/src/core/wasm/msgs/MsgInstantiateContract.ts
+++ b/src/core/wasm/msgs/MsgInstantiateContract.ts
@@ -35,196 +35,109 @@ export class MsgInstantiateContract extends JSONSerializable<
 
   public static fromAmino(
     data: MsgInstantiateContract.Amino,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): MsgInstantiateContract {
-    if (isClassic) {
-      const {
-        value: { sender, admin, code_id, init_msg, init_coins },
-      } = data as MsgInstantiateContract.AminoV1;
-      return new MsgInstantiateContract(
-        sender,
-        admin,
-        Number.parseInt(code_id),
-        init_msg,
-        Coins.fromAmino(init_coins)
-      );
-    }
-    {
-      const {
-        value: { sender, admin, code_id, msg, funds, label },
-      } = data as MsgInstantiateContract.AminoV2;
-      return new MsgInstantiateContract(
-        sender,
-        admin,
-        Number.parseInt(code_id),
-        msg,
-        Coins.fromAmino(funds),
-        label
-      );
-    }
+    const {
+      value: { sender, admin, code_id, msg, funds, label },
+    } = data as MsgInstantiateContract.AminoV2;
+    return new MsgInstantiateContract(
+      sender,
+      admin,
+      Number.parseInt(code_id),
+      msg,
+      Coins.fromAmino(funds),
+      label
+    );
   }
 
-  public toAmino(isClassic?: boolean): MsgInstantiateContract.Amino {
+  public toAmino(_isClassic?: boolean): MsgInstantiateContract.Amino {
     const { sender, admin, code_id, init_msg, init_coins, label } = this;
-    if (isClassic) {
-      return {
-        type: 'wasm/MsgInstantiateContract',
-        value: {
-          sender,
-          admin,
-          code_id: code_id.toFixed(),
-          init_msg: removeNull(init_msg),
-          init_coins: init_coins.toAmino(),
-        },
-      };
-    } else {
-      return {
-        type: 'wasm/MsgInstantiateContract',
-        value: {
-          sender,
-          admin,
-          code_id: code_id.toFixed(),
-          label,
-          msg: removeNull(init_msg),
-          funds: init_coins.toAmino(),
-        },
-      };
-    }
+    return {
+      type: 'wasm/MsgInstantiateContract',
+      value: {
+        sender,
+        admin,
+        code_id: code_id.toFixed(),
+        label,
+        msg: removeNull(init_msg),
+        funds: init_coins.toAmino(),
+      },
+    };
   }
 
   public static fromProto(
     proto: MsgInstantiateContract.Proto,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): MsgInstantiateContract {
-    if (isClassic) {
-      const p = proto as MsgInstantiateContract_legacy_pb;
-      return new MsgInstantiateContract(
-        p.sender,
-        p.admin !== '' ? p.admin : undefined,
-        p.codeId.toNumber(),
-        JSON.parse(Buffer.from(p.initMsg).toString('utf-8')),
-        Coins.fromProto(p.initCoins)
-      );
-    } else {
-      const p = proto as MsgInstantiateContract_pb;
-      return new MsgInstantiateContract(
-        p.sender,
-        p.admin !== '' ? p.admin : undefined,
-        p.codeId.toNumber(),
-        JSON.parse(Buffer.from(p.msg).toString('utf-8')),
-        Coins.fromProto(p.funds),
-        p.label !== '' ? p.label : undefined
-      );
-    }
+    const p = proto as MsgInstantiateContract_pb;
+    return new MsgInstantiateContract(
+      p.sender,
+      p.admin !== '' ? p.admin : undefined,
+      p.codeId.toNumber(),
+      JSON.parse(Buffer.from(p.msg).toString('utf-8')),
+      Coins.fromProto(p.funds),
+      p.label !== '' ? p.label : undefined
+    );
   }
 
-  public toProto(isClassic?: boolean): MsgInstantiateContract.Proto {
+  public toProto(_isClassic?: boolean): MsgInstantiateContract.Proto {
     const { sender, admin, code_id, init_msg, init_coins, label } = this;
-    if (isClassic) {
-      return MsgInstantiateContract_legacy_pb.fromPartial({
-        admin,
-        codeId: Long.fromNumber(code_id),
-        initCoins: init_coins.toProto(),
-        initMsg: Buffer.from(JSON.stringify(init_msg), 'utf-8'),
-        sender,
-      });
-    } else {
-      return MsgInstantiateContract_pb.fromPartial({
-        admin,
-        codeId: Long.fromNumber(code_id),
-        funds: init_coins.toProto(),
-        msg: Buffer.from(JSON.stringify(init_msg), 'utf-8'),
-        sender,
-        label,
-      });
-    }
+    return MsgInstantiateContract_pb.fromPartial({
+      admin,
+      codeId: Long.fromNumber(code_id),
+      funds: init_coins.toProto(),
+      msg: Buffer.from(JSON.stringify(init_msg), 'utf-8'),
+      sender,
+      label,
+    });
   }
 
   public packAny(isClassic?: boolean): Any {
-    if (isClassic) {
-      return Any.fromPartial({
-        typeUrl: '/terra.wasm.v1beta1.MsgInstantiateContract',
-        value: MsgInstantiateContract_legacy_pb.encode(
-          this.toProto(isClassic) as MsgInstantiateContract_legacy_pb
-        ).finish(),
-      });
-    } else {
-      return Any.fromPartial({
-        typeUrl: '/cosmwasm.wasm.v1.MsgInstantiateContract',
-        value: MsgInstantiateContract_pb.encode(
-          this.toProto(isClassic) as MsgInstantiateContract_pb
-        ).finish(),
-      });
-    }
+    return Any.fromPartial({
+      typeUrl: '/cosmwasm.wasm.v1.MsgInstantiateContract',
+      value: MsgInstantiateContract_pb.encode(
+        this.toProto(isClassic) as MsgInstantiateContract_pb
+      ).finish(),
+    });
   }
 
   public static unpackAny(
     msgAny: Any,
     isClassic?: boolean
   ): MsgInstantiateContract {
-    if (isClassic) {
-      return MsgInstantiateContract.fromProto(
-        MsgInstantiateContract_legacy_pb.decode(msgAny.value),
-        isClassic
-      );
-    } else {
-      return MsgInstantiateContract.fromProto(
-        MsgInstantiateContract_pb.decode(msgAny.value),
-        isClassic
-      );
-    }
+    return MsgInstantiateContract.fromProto(
+      MsgInstantiateContract_pb.decode(msgAny.value),
+      isClassic
+    );
   }
 
   public static fromData(
     data: MsgInstantiateContract.Data,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): MsgInstantiateContract {
-    if (isClassic) {
-      const { sender, admin, code_id, init_msg, init_coins } =
-        data as MsgInstantiateContract.DataV1;
-      return new MsgInstantiateContract(
-        sender,
-        admin !== '' ? admin : undefined,
-        Number.parseInt(code_id),
-        init_msg,
-        Coins.fromData(init_coins)
-      );
-    } else {
-      const { sender, admin, code_id, label, msg, funds } =
-        data as MsgInstantiateContract.DataV2;
-      return new MsgInstantiateContract(
-        sender,
-        admin !== '' ? admin : undefined,
-        Number.parseInt(code_id),
-        msg,
-        Coins.fromData(funds),
-        label
-      );
-    }
+    const { sender, admin, code_id, label, msg, funds } =
+      data as MsgInstantiateContract.DataV2;
+    return new MsgInstantiateContract(
+      sender,
+      admin !== '' ? admin : undefined,
+      Number.parseInt(code_id),
+      msg,
+      Coins.fromData(funds),
+      label
+    );
   }
 
-  public toData(isClassic?: boolean): MsgInstantiateContract.Data {
+  public toData(_isClassic?: boolean): MsgInstantiateContract.Data {
     const { sender, admin, code_id, label, init_msg, init_coins } = this;
-    if (isClassic) {
-      return {
-        '@type': '/terra.wasm.v1beta1.MsgInstantiateContract',
-        sender,
-        admin: admin || '',
-        code_id: code_id.toFixed(),
-        init_msg: removeNull(init_msg),
-        init_coins: init_coins.toData(),
-      };
-    } else {
-      return {
-        '@type': '/cosmwasm.wasm.v1.MsgInstantiateContract',
-        sender,
-        admin: admin || '',
-        code_id: code_id.toFixed(),
-        label,
-        msg: removeNull(init_msg),
-        funds: init_coins.toData(),
-      };
-    }
+    return {
+      '@type': '/cosmwasm.wasm.v1.MsgInstantiateContract',
+      sender,
+      admin: admin || '',
+      code_id: code_id.toFixed(),
+      label,
+      msg: removeNull(init_msg),
+      funds: init_coins.toData(),
+    };
   }
 }
 

--- a/src/core/wasm/msgs/MsgInstantiateContract.ts
+++ b/src/core/wasm/msgs/MsgInstantiateContract.ts
@@ -35,7 +35,7 @@ export class MsgInstantiateContract extends JSONSerializable<
 
   public static fromAmino(
     data: MsgInstantiateContract.Amino,
-    _isClassic?: boolean
+    _?: boolean
   ): MsgInstantiateContract {
     const {
       value: { sender, admin, code_id, msg, funds, label },
@@ -50,7 +50,7 @@ export class MsgInstantiateContract extends JSONSerializable<
     );
   }
 
-  public toAmino(_isClassic?: boolean): MsgInstantiateContract.Amino {
+  public toAmino(_?: boolean): MsgInstantiateContract.Amino {
     const { sender, admin, code_id, init_msg, init_coins, label } = this;
     return {
       type: 'wasm/MsgInstantiateContract',
@@ -67,7 +67,7 @@ export class MsgInstantiateContract extends JSONSerializable<
 
   public static fromProto(
     proto: MsgInstantiateContract.Proto,
-    _isClassic?: boolean
+    _?: boolean
   ): MsgInstantiateContract {
     const p = proto as MsgInstantiateContract_pb;
     return new MsgInstantiateContract(
@@ -80,7 +80,7 @@ export class MsgInstantiateContract extends JSONSerializable<
     );
   }
 
-  public toProto(_isClassic?: boolean): MsgInstantiateContract.Proto {
+  public toProto(_?: boolean): MsgInstantiateContract.Proto {
     const { sender, admin, code_id, init_msg, init_coins, label } = this;
     return MsgInstantiateContract_pb.fromPartial({
       admin,
@@ -113,7 +113,7 @@ export class MsgInstantiateContract extends JSONSerializable<
 
   public static fromData(
     data: MsgInstantiateContract.Data,
-    _isClassic?: boolean
+    _?: boolean
   ): MsgInstantiateContract {
     const { sender, admin, code_id, label, msg, funds } =
       data as MsgInstantiateContract.DataV2;
@@ -127,7 +127,7 @@ export class MsgInstantiateContract extends JSONSerializable<
     );
   }
 
-  public toData(_isClassic?: boolean): MsgInstantiateContract.Data {
+  public toData(_?: boolean): MsgInstantiateContract.Data {
     const { sender, admin, code_id, label, init_msg, init_coins } = this;
     return {
       '@type': '/cosmwasm.wasm.v1.MsgInstantiateContract',

--- a/src/core/wasm/msgs/MsgMigrateCode.ts
+++ b/src/core/wasm/msgs/MsgMigrateCode.ts
@@ -24,42 +24,42 @@ export class MsgMigrateCode extends JSONSerializable<
 
   public static fromAmino(
     _data: MsgMigrateCode.Amino,
-    _isClassic?: boolean
+    _?: boolean
   ): MsgMigrateCode {
     throw new Error('Not supported for the network');
   }
 
-  public toAmino(_isClassic?: boolean): MsgMigrateCode.Amino {
+  public toAmino(_?: boolean): MsgMigrateCode.Amino {
     throw new Error('Not supported for the network');
   }
 
   public static fromProto(
     _proto: MsgMigrateCode.Proto,
-    _isClassic?: boolean
+    _?: boolean
   ): MsgMigrateCode {
     throw new Error('Not supported for the network');
   }
 
-  public toProto(_isClassic?: boolean): MsgMigrateCode.Proto {
+  public toProto(_?: boolean): MsgMigrateCode.Proto {
     throw new Error('Not supported for the network');
   }
 
-  public packAny(_isClassic?: boolean): Any {
+  public packAny(_?: boolean): Any {
     throw new Error('Not supported for the network');
   }
 
-  public static unpackAny(_msgAny: Any, _isClassic?: boolean): MsgMigrateCode {
+  public static unpackAny(_msgAny: Any, _?: boolean): MsgMigrateCode {
     throw new Error('Not supported for the network');
   }
 
   public static fromData(
     _data: MsgMigrateCode.Data,
-    _isClassic?: boolean
+    _?: boolean
   ): MsgMigrateCode {
     throw new Error('Not supported for the network');
   }
 
-  public toData(_isClassic?: boolean): MsgMigrateCode.Data {
+  public toData(_?: boolean): MsgMigrateCode.Data {
     throw new Error('Not supported for the network');
   }
 }

--- a/src/core/wasm/msgs/MsgMigrateCode.ts
+++ b/src/core/wasm/msgs/MsgMigrateCode.ts
@@ -23,101 +23,44 @@ export class MsgMigrateCode extends JSONSerializable<
   }
 
   public static fromAmino(
-    data: MsgMigrateCode.Amino,
-    isClassic?: boolean
+    _data: MsgMigrateCode.Amino,
+    _isClassic?: boolean
   ): MsgMigrateCode {
-    if (!isClassic) {
-      throw new Error('Not supported for the network');
-    }
-    const {
-      value: { sender, code_id, wasm_byte_code },
-    } = data;
-    return new MsgMigrateCode(sender, Number.parseInt(code_id), wasm_byte_code);
+    throw new Error('Not supported for the network');
   }
 
-  public toAmino(isClassic?: boolean): MsgMigrateCode.Amino {
-    if (!isClassic) {
-      throw new Error('Not supported for the network');
-    }
-    const { sender, code_id, wasm_byte_code } = this;
-    return {
-      type: 'wasm/MsgMigrateCode',
-      value: {
-        sender,
-        code_id: code_id.toFixed(),
-        wasm_byte_code,
-      },
-    };
+  public toAmino(_isClassic?: boolean): MsgMigrateCode.Amino {
+    throw new Error('Not supported for the network');
   }
 
   public static fromProto(
-    proto: MsgMigrateCode.Proto,
-    isClassic?: boolean
+    _proto: MsgMigrateCode.Proto,
+    _isClassic?: boolean
   ): MsgMigrateCode {
-    if (!isClassic) {
-      throw new Error('Not supported for the network');
-    }
-    return new MsgMigrateCode(
-      proto.sender,
-      proto.codeId.toNumber(),
-      Buffer.from(proto.wasmByteCode).toString('base64')
-    );
+    throw new Error('Not supported for the network');
   }
 
-  public toProto(isClassic?: boolean): MsgMigrateCode.Proto {
-    if (!isClassic) {
-      throw new Error('Not supported for the network');
-    }
-    const { sender, code_id, wasm_byte_code } = this;
-    return MsgMigrateCode_legacy_pb.fromPartial({
-      codeId: Long.fromNumber(code_id),
-      sender,
-      wasmByteCode: Buffer.from(wasm_byte_code, 'base64'),
-    });
+  public toProto(_isClassic?: boolean): MsgMigrateCode.Proto {
+    throw new Error('Not supported for the network');
   }
 
-  public packAny(isClassic?: boolean): Any {
-    if (!isClassic) {
-      throw new Error('Not supported for the network');
-    }
-    return Any.fromPartial({
-      typeUrl: '/terra.wasm.v1beta1.MsgMigrateCode',
-      value: MsgMigrateCode_legacy_pb.encode(this.toProto(isClassic)).finish(),
-    });
+  public packAny(_isClassic?: boolean): Any {
+    throw new Error('Not supported for the network');
   }
 
-  public static unpackAny(msgAny: Any, isClassic?: boolean): MsgMigrateCode {
-    if (!isClassic) {
-      throw new Error('Not supported for the network');
-    }
-    return MsgMigrateCode.fromProto(
-      MsgMigrateCode_legacy_pb.decode(msgAny.value),
-      isClassic
-    );
+  public static unpackAny(_msgAny: Any, _isClassic?: boolean): MsgMigrateCode {
+    throw new Error('Not supported for the network');
   }
 
   public static fromData(
-    data: MsgMigrateCode.Data,
-    isClassic?: boolean
+    _data: MsgMigrateCode.Data,
+    _isClassic?: boolean
   ): MsgMigrateCode {
-    if (!isClassic) {
-      throw new Error('Not supported for the network');
-    }
-    const { sender, code_id, wasm_byte_code } = data;
-    return new MsgMigrateCode(sender, Number.parseInt(code_id), wasm_byte_code);
+    throw new Error('Not supported for the network');
   }
 
-  public toData(isClassic?: boolean): MsgMigrateCode.Data {
-    if (!isClassic) {
-      throw new Error('Not supported for the network');
-    }
-    const { sender, code_id, wasm_byte_code } = this;
-    return {
-      '@type': '/terra.wasm.v1beta1.MsgMigrateCode',
-      sender,
-      code_id: code_id.toFixed(),
-      wasm_byte_code,
-    };
+  public toData(_isClassic?: boolean): MsgMigrateCode.Data {
+    throw new Error('Not supported for the network');
   }
 }
 

--- a/src/core/wasm/msgs/MsgMigrateContract.spec.ts
+++ b/src/core/wasm/msgs/MsgMigrateContract.spec.ts
@@ -17,42 +17,15 @@ const msgWithMigrateString = new MsgMigrateContract(
 );
 
 describe('MsgMigrateContract', () => {
-  it('legacy amino', () => {
-    const aminoWithAdmin = msgWithAdmin.toAmino(true) as MsgMigrateContract.AminoV1;
-    expect(aminoWithAdmin.value.admin).toEqual(msgWithAdmin.admin);
-
-    const aminoWithMigrateString = msgWithMigrateString.toAmino(true) as MsgMigrateContract.AminoV1;
-    expect(aminoWithMigrateString.value.migrate_msg).toEqual(
-      msgWithMigrateString.migrate_msg
-    );
-  });
-
-  it('legacy proto', () => {
-    const protoWithAdmin = msgWithAdmin.toProto(true) as MsgMigrateContract_legacy_pb;
-    expect(protoWithAdmin.admin).toEqual(msgWithAdmin.admin);
-
-    const protoWithMigrateString = msgWithMigrateString.toProto(true) as MsgMigrateContract_legacy_pb;
-    expect(protoWithMigrateString.migrateMsg.toString()).toEqual(
-      JSON.stringify(msgWithMigrateString.migrate_msg)
-    );
-  });
-
-  it('legacy data', () => {
-    const dataWithAdmin = msgWithAdmin.toData(true) as MsgMigrateContract.DataV1;
-    expect(dataWithAdmin.admin).toEqual(msgWithAdmin.admin);
-
-    const dataWithMigrateString = msgWithMigrateString.toData(true) as MsgMigrateContract.DataV1;
-    expect(dataWithMigrateString.migrate_msg).toEqual(
-      msgWithMigrateString.migrate_msg
-    );
-  });
-
-
   it('amino', () => {
-    const aminoWithAdmin = msgWithAdmin.toAmino(false) as MsgMigrateContract.AminoV2;
+    const aminoWithAdmin = msgWithAdmin.toAmino(
+      false
+    ) as MsgMigrateContract.AminoV2;
     expect(aminoWithAdmin.value.sender).toEqual(msgWithAdmin.admin);
 
-    const aminoWithMigrateString = msgWithMigrateString.toAmino(false) as MsgMigrateContract.AminoV2;
+    const aminoWithMigrateString = msgWithMigrateString.toAmino(
+      false
+    ) as MsgMigrateContract.AminoV2;
     expect(aminoWithMigrateString.value.msg).toEqual(
       msgWithMigrateString.migrate_msg
     );
@@ -62,19 +35,23 @@ describe('MsgMigrateContract', () => {
     const protoWithAdmin = msgWithAdmin.toProto(false) as MsgMigrateContract_pb;
     expect(protoWithAdmin.sender).toEqual(msgWithAdmin.admin);
 
-    const protoWithMigrateString = msgWithMigrateString.toProto(false) as MsgMigrateContract_pb;
+    const protoWithMigrateString = msgWithMigrateString.toProto(
+      false
+    ) as MsgMigrateContract_pb;
     expect(protoWithMigrateString.msg.toString()).toEqual(
       JSON.stringify(msgWithMigrateString.migrate_msg)
     );
   });
 
   it('data', () => {
-    const dataWithAdmin = msgWithAdmin.toData(false) as MsgMigrateContract.DataV2;
+    const dataWithAdmin = msgWithAdmin.toData(
+      false
+    ) as MsgMigrateContract.DataV2;
     expect(dataWithAdmin.sender).toEqual(msgWithAdmin.admin);
 
-    const dataWithMigrateString = msgWithMigrateString.toData(false) as MsgMigrateContract.DataV2;
-    expect(dataWithMigrateString.msg).toEqual(
-      msgWithMigrateString.migrate_msg
-    );
+    const dataWithMigrateString = msgWithMigrateString.toData(
+      false
+    ) as MsgMigrateContract.DataV2;
+    expect(dataWithMigrateString.msg).toEqual(msgWithMigrateString.migrate_msg);
   });
 });

--- a/src/core/wasm/msgs/MsgMigrateContract.ts
+++ b/src/core/wasm/msgs/MsgMigrateContract.ts
@@ -27,7 +27,7 @@ export class MsgMigrateContract extends JSONSerializable<
 
   public static fromAmino(
     data: MsgMigrateContract.Amino,
-    _isClassic?: boolean
+    _?: boolean
   ): MsgMigrateContract {
     const {
       value: { sender, contract, code_id, msg },
@@ -40,7 +40,7 @@ export class MsgMigrateContract extends JSONSerializable<
     );
   }
 
-  public toAmino(_isClassic?: boolean): MsgMigrateContract.Amino {
+  public toAmino(_?: boolean): MsgMigrateContract.Amino {
     const { admin, contract, new_code_id, migrate_msg } = this;
     return {
       type: 'wasm/MsgMigrateContract',
@@ -55,7 +55,7 @@ export class MsgMigrateContract extends JSONSerializable<
 
   public static fromProto(
     proto: MsgMigrateContract.Proto,
-    _isClassic?: boolean
+    _?: boolean
   ): MsgMigrateContract {
     const p = proto as MsgMigrateContract_pb;
     return new MsgMigrateContract(
@@ -66,7 +66,7 @@ export class MsgMigrateContract extends JSONSerializable<
     );
   }
 
-  public toProto(_isClassic?: boolean): MsgMigrateContract.Proto {
+  public toProto(_?: boolean): MsgMigrateContract.Proto {
     const { admin, contract, new_code_id, migrate_msg } = this;
     return MsgMigrateContract_pb.fromPartial({
       sender: admin,
@@ -96,7 +96,7 @@ export class MsgMigrateContract extends JSONSerializable<
 
   public static fromData(
     data: MsgMigrateContract.Data,
-    _isClassic?: boolean
+    _?: boolean
   ): MsgMigrateContract {
     const { sender, contract, code_id, msg } =
       data as MsgMigrateContract.DataV2;
@@ -108,7 +108,7 @@ export class MsgMigrateContract extends JSONSerializable<
     );
   }
 
-  public toData(_isClassic?: boolean): MsgMigrateContract.Data {
+  public toData(_?: boolean): MsgMigrateContract.Data {
     const { admin, contract, new_code_id, migrate_msg } = this;
     return {
       '@type': '/cosmwasm.wasm.v1.MsgMigrateContract',

--- a/src/core/wasm/msgs/MsgMigrateContract.ts
+++ b/src/core/wasm/msgs/MsgMigrateContract.ts
@@ -27,114 +27,61 @@ export class MsgMigrateContract extends JSONSerializable<
 
   public static fromAmino(
     data: MsgMigrateContract.Amino,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): MsgMigrateContract {
-    if (isClassic) {
-      const {
-        value: { admin, contract, new_code_id, migrate_msg },
-      } = data as MsgMigrateContract.AminoV1;
-      return new MsgMigrateContract(
-        admin,
-        contract,
-        Number.parseInt(new_code_id),
-        migrate_msg
-      );
-    } else {
-      const {
-        value: { sender, contract, code_id, msg },
-      } = data as MsgMigrateContract.AminoV2;
-      return new MsgMigrateContract(
-        sender,
-        contract,
-        Number.parseInt(code_id),
-        msg
-      );
-    }
+    const {
+      value: { sender, contract, code_id, msg },
+    } = data as MsgMigrateContract.AminoV2;
+    return new MsgMigrateContract(
+      sender,
+      contract,
+      Number.parseInt(code_id),
+      msg
+    );
   }
 
-  public toAmino(isClassic?: boolean): MsgMigrateContract.Amino {
-    if (isClassic) {
-      const { admin, contract, new_code_id, migrate_msg } = this;
-      return {
-        type: 'wasm/MsgMigrateContract',
-        value: {
-          admin,
-          contract,
-          new_code_id: new_code_id.toFixed(),
-          migrate_msg: removeNull(migrate_msg),
-        },
-      };
-    } else {
-      const { admin, contract, new_code_id, migrate_msg } = this;
-      return {
-        type: 'wasm/MsgMigrateContract',
-        value: {
-          sender: admin,
-          contract,
-          code_id: new_code_id.toFixed(),
-          msg: removeNull(migrate_msg),
-        },
-      };
-    }
+  public toAmino(_isClassic?: boolean): MsgMigrateContract.Amino {
+    const { admin, contract, new_code_id, migrate_msg } = this;
+    return {
+      type: 'wasm/MsgMigrateContract',
+      value: {
+        sender: admin,
+        contract,
+        code_id: new_code_id.toFixed(),
+        msg: removeNull(migrate_msg),
+      },
+    };
   }
 
   public static fromProto(
     proto: MsgMigrateContract.Proto,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): MsgMigrateContract {
-    if (isClassic) {
-      const p = proto as MsgMigrateContract_legacy_pb;
-      return new MsgMigrateContract(
-        p.admin,
-        p.contract,
-        p.newCodeId.toNumber(),
-        JSON.parse(Buffer.from(p.migrateMsg).toString('utf-8'))
-      );
-    } else {
-      const p = proto as MsgMigrateContract_pb;
-      return new MsgMigrateContract(
-        p.sender,
-        p.contract,
-        p.codeId.toNumber(),
-        JSON.parse(Buffer.from(p.msg).toString('utf-8'))
-      );
-    }
+    const p = proto as MsgMigrateContract_pb;
+    return new MsgMigrateContract(
+      p.sender,
+      p.contract,
+      p.codeId.toNumber(),
+      JSON.parse(Buffer.from(p.msg).toString('utf-8'))
+    );
   }
 
-  public toProto(isClassic?: boolean): MsgMigrateContract.Proto {
+  public toProto(_isClassic?: boolean): MsgMigrateContract.Proto {
     const { admin, contract, new_code_id, migrate_msg } = this;
-    if (isClassic) {
-      return MsgMigrateContract_legacy_pb.fromPartial({
-        admin,
-        contract,
-        newCodeId: Long.fromNumber(new_code_id),
-        migrateMsg: Buffer.from(JSON.stringify(migrate_msg), 'utf-8'),
-      });
-    } else {
-      return MsgMigrateContract_pb.fromPartial({
-        sender: admin,
-        contract,
-        codeId: Long.fromNumber(new_code_id),
-        msg: Buffer.from(JSON.stringify(migrate_msg), 'utf-8'),
-      });
-    }
+    return MsgMigrateContract_pb.fromPartial({
+      sender: admin,
+      contract,
+      codeId: Long.fromNumber(new_code_id),
+      msg: Buffer.from(JSON.stringify(migrate_msg), 'utf-8'),
+    });
   }
   public packAny(isClassic?: boolean): Any {
-    if (isClassic) {
-      return Any.fromPartial({
-        typeUrl: '/terra.wasm.v1beta1.MsgMigrateContract',
-        value: MsgMigrateContract_legacy_pb.encode(
-          this.toProto(isClassic) as MsgMigrateContract_legacy_pb
-        ).finish(),
-      });
-    } else {
-      return Any.fromPartial({
-        typeUrl: '/cosmwasm.wasm.v1.MsgMigrateContract',
-        value: MsgMigrateContract_pb.encode(
-          this.toProto(isClassic) as MsgMigrateContract_pb
-        ).finish(),
-      });
-    }
+    return Any.fromPartial({
+      typeUrl: '/cosmwasm.wasm.v1.MsgMigrateContract',
+      value: MsgMigrateContract_pb.encode(
+        this.toProto(isClassic) as MsgMigrateContract_pb
+      ).finish(),
+    });
   }
 
   public static unpackAny(
@@ -142,57 +89,34 @@ export class MsgMigrateContract extends JSONSerializable<
     isClassic?: boolean
   ): MsgMigrateContract {
     return MsgMigrateContract.fromProto(
-      isClassic
-        ? MsgMigrateContract_legacy_pb.decode(msgAny.value)
-        : MsgMigrateContract_pb.decode(msgAny.value),
+      MsgMigrateContract_pb.decode(msgAny.value),
       isClassic
     );
   }
 
   public static fromData(
     data: MsgMigrateContract.Data,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): MsgMigrateContract {
-    if (isClassic) {
-      const { admin, contract, new_code_id, migrate_msg } =
-        data as MsgMigrateContract.DataV1;
-      return new MsgMigrateContract(
-        admin,
-        contract,
-        Number.parseInt(new_code_id),
-        migrate_msg
-      );
-    } else {
-      const { sender, contract, code_id, msg } =
-        data as MsgMigrateContract.DataV2;
-      return new MsgMigrateContract(
-        sender,
-        contract,
-        Number.parseInt(code_id),
-        msg
-      );
-    }
+    const { sender, contract, code_id, msg } =
+      data as MsgMigrateContract.DataV2;
+    return new MsgMigrateContract(
+      sender,
+      contract,
+      Number.parseInt(code_id),
+      msg
+    );
   }
 
-  public toData(isClassic?: boolean): MsgMigrateContract.Data {
+  public toData(_isClassic?: boolean): MsgMigrateContract.Data {
     const { admin, contract, new_code_id, migrate_msg } = this;
-    if (isClassic) {
-      return {
-        '@type': '/terra.wasm.v1beta1.MsgMigrateContract',
-        admin,
-        contract,
-        new_code_id: new_code_id.toFixed(),
-        migrate_msg: removeNull(migrate_msg),
-      };
-    } else {
-      return {
-        '@type': '/cosmwasm.wasm.v1.MsgMigrateContract',
-        sender: admin,
-        contract,
-        code_id: new_code_id.toFixed(),
-        msg: removeNull(migrate_msg),
-      };
-    }
+    return {
+      '@type': '/cosmwasm.wasm.v1.MsgMigrateContract',
+      sender: admin,
+      contract,
+      code_id: new_code_id.toFixed(),
+      msg: removeNull(migrate_msg),
+    };
   }
 }
 

--- a/src/core/wasm/msgs/MsgStoreCode.ts
+++ b/src/core/wasm/msgs/MsgStoreCode.ts
@@ -25,7 +25,7 @@ export class MsgStoreCode extends JSONSerializable<
 
   public static fromAmino(
     data: MsgStoreCode.AminoV2 | MsgStoreCode.AminoV1,
-    _isClassic?: boolean
+    _?: boolean
   ): MsgStoreCode {
     const {
       value: { sender, wasm_byte_code, instantiate_permission },
@@ -39,7 +39,7 @@ export class MsgStoreCode extends JSONSerializable<
     );
   }
 
-  public toAmino(_isClassic?: boolean): MsgStoreCode.AminoV2 {
+  public toAmino(_?: boolean): MsgStoreCode.AminoV2 {
     const { sender, wasm_byte_code, instantiate_permission } = this;
     return {
       type: 'wasm/MsgStoreCode',
@@ -53,7 +53,7 @@ export class MsgStoreCode extends JSONSerializable<
 
   public static fromProto(
     proto: MsgStoreCode.Proto,
-    _isClassic?: boolean
+    _?: boolean
   ): MsgStoreCode {
     const p = proto as MsgStoreCode_pb;
     return new MsgStoreCode(
@@ -65,7 +65,7 @@ export class MsgStoreCode extends JSONSerializable<
     );
   }
 
-  public toProto(_isClassic?: boolean): MsgStoreCode.Proto {
+  public toProto(_?: boolean): MsgStoreCode.Proto {
     const { sender, wasm_byte_code, instantiate_permission } = this;
     return MsgStoreCode_pb.fromPartial({
       sender,
@@ -91,7 +91,7 @@ export class MsgStoreCode extends JSONSerializable<
 
   public static fromData(
     data: MsgStoreCode.DataV2 | MsgStoreCode.DataV1,
-    _isClassic?: boolean
+    _?: boolean
   ): MsgStoreCode {
     const { sender, wasm_byte_code, instantiate_permission } =
       data as MsgStoreCode.DataV2;
@@ -104,7 +104,7 @@ export class MsgStoreCode extends JSONSerializable<
     );
   }
 
-  public toData(_isClassic?: boolean): MsgStoreCode.Data {
+  public toData(_?: boolean): MsgStoreCode.Data {
     const { sender, wasm_byte_code, instantiate_permission } = this;
     return {
       '@type': '/cosmwasm.wasm.v1.MsgStoreCode',

--- a/src/core/wasm/msgs/MsgStoreCode.ts
+++ b/src/core/wasm/msgs/MsgStoreCode.ts
@@ -25,152 +25,93 @@ export class MsgStoreCode extends JSONSerializable<
 
   public static fromAmino(
     data: MsgStoreCode.AminoV2 | MsgStoreCode.AminoV1,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): MsgStoreCode {
-    if (isClassic) {
-      const {
-        value: { sender, wasm_byte_code },
-      } = data as MsgStoreCode.AminoV1;
-      return new MsgStoreCode(sender, wasm_byte_code);
-    } else {
-      const {
-        value: { sender, wasm_byte_code, instantiate_permission },
-      } = data as MsgStoreCode.AminoV2;
-      return new MsgStoreCode(
-        sender,
-        wasm_byte_code,
-        instantiate_permission
-          ? AccessConfig.fromAmino(instantiate_permission)
-          : undefined
-      );
-    }
+    const {
+      value: { sender, wasm_byte_code, instantiate_permission },
+    } = data as MsgStoreCode.AminoV2;
+    return new MsgStoreCode(
+      sender,
+      wasm_byte_code,
+      instantiate_permission
+        ? AccessConfig.fromAmino(instantiate_permission)
+        : undefined
+    );
   }
 
-  public toAmino(isClassic?: boolean): MsgStoreCode.AminoV2 {
+  public toAmino(_isClassic?: boolean): MsgStoreCode.AminoV2 {
     const { sender, wasm_byte_code, instantiate_permission } = this;
-    if (isClassic) {
-      return {
-        type: 'wasm/MsgStoreCode',
-        value: {
-          sender,
-          wasm_byte_code,
-        },
-      };
-    } else {
-      return {
-        type: 'wasm/MsgStoreCode',
-        value: {
-          sender,
-          wasm_byte_code,
-          instantiate_permission: instantiate_permission?.toAmino(),
-        },
-      };
-    }
+    return {
+      type: 'wasm/MsgStoreCode',
+      value: {
+        sender,
+        wasm_byte_code,
+        instantiate_permission: instantiate_permission?.toAmino(),
+      },
+    };
   }
 
   public static fromProto(
     proto: MsgStoreCode.Proto,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): MsgStoreCode {
-    if (isClassic) {
-      return new MsgStoreCode(
-        proto.sender,
-        Buffer.from(proto.wasmByteCode).toString('base64')
-      );
-    } else {
-      const p = proto as MsgStoreCode_pb;
-      return new MsgStoreCode(
-        p.sender,
-        Buffer.from(p.wasmByteCode).toString('base64'),
-        p.instantiatePermission
-          ? AccessConfig.fromProto(p.instantiatePermission)
-          : undefined
-      );
-    }
+    const p = proto as MsgStoreCode_pb;
+    return new MsgStoreCode(
+      p.sender,
+      Buffer.from(p.wasmByteCode).toString('base64'),
+      p.instantiatePermission
+        ? AccessConfig.fromProto(p.instantiatePermission)
+        : undefined
+    );
   }
 
-  public toProto(isClassic?: boolean): MsgStoreCode.Proto {
+  public toProto(_isClassic?: boolean): MsgStoreCode.Proto {
     const { sender, wasm_byte_code, instantiate_permission } = this;
-    if (isClassic) {
-      return MsgStoreCode_legacy_pb.fromPartial({
-        sender,
-        wasmByteCode: Buffer.from(wasm_byte_code, 'base64'),
-      });
-    } else {
-      return MsgStoreCode_pb.fromPartial({
-        sender,
-        wasmByteCode: Buffer.from(wasm_byte_code, 'base64'),
-        instantiatePermission: instantiate_permission?.toProto(),
-      });
-    }
+    return MsgStoreCode_pb.fromPartial({
+      sender,
+      wasmByteCode: Buffer.from(wasm_byte_code, 'base64'),
+      instantiatePermission: instantiate_permission?.toProto(),
+    });
   }
 
   public packAny(isClassic?: boolean): Any {
-    let typeUrl: string;
-    if (isClassic) {
-      typeUrl = '/terra.wasm.v1beta1.MsgStoreCode';
-    } else {
-      typeUrl = '/cosmwasm.wasm.v1.MsgStoreCode';
-    }
     const any = Any.fromPartial({
-      typeUrl,
-      value: isClassic
-        ? MsgStoreCode_legacy_pb.encode(this.toProto(isClassic)).finish()
-        : MsgStoreCode_pb.encode(this.toProto(isClassic)).finish(),
+      typeUrl: '/cosmwasm.wasm.v1.MsgStoreCode',
+      value: MsgStoreCode_pb.encode(this.toProto(isClassic)).finish(),
     });
     return any;
   }
 
   public static unpackAny(msgAny: Any, isClassic?: boolean): MsgStoreCode {
-    if (isClassic) {
-      return MsgStoreCode.fromProto(
-        MsgStoreCode_legacy_pb.decode(msgAny.value),
-        isClassic
-      );
-    } else {
-      return MsgStoreCode.fromProto(
-        MsgStoreCode_pb.decode(msgAny.value),
-        isClassic
-      );
-    }
+    return MsgStoreCode.fromProto(
+      MsgStoreCode_pb.decode(msgAny.value),
+      isClassic
+    );
   }
 
   public static fromData(
     data: MsgStoreCode.DataV2 | MsgStoreCode.DataV1,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): MsgStoreCode {
-    if (isClassic) {
-      const { sender, wasm_byte_code } = data as MsgStoreCode.DataV1;
-      return new MsgStoreCode(sender, wasm_byte_code);
-    } else {
-      const { sender, wasm_byte_code, instantiate_permission } =
-        data as MsgStoreCode.DataV2;
-      return new MsgStoreCode(
-        sender,
-        wasm_byte_code,
-        instantiate_permission
-          ? AccessConfig.fromData(instantiate_permission)
-          : undefined
-      );
-    }
+    const { sender, wasm_byte_code, instantiate_permission } =
+      data as MsgStoreCode.DataV2;
+    return new MsgStoreCode(
+      sender,
+      wasm_byte_code,
+      instantiate_permission
+        ? AccessConfig.fromData(instantiate_permission)
+        : undefined
+    );
   }
 
-  public toData(isClassic?: boolean): MsgStoreCode.Data {
+  public toData(_isClassic?: boolean): MsgStoreCode.Data {
     const { sender, wasm_byte_code, instantiate_permission } = this;
-    if (isClassic) {
-      return {
-        '@type': '/terra.wasm.v1beta1.MsgStoreCode',
-        sender,
-        wasm_byte_code,
-      };
-    } else {
-      return {
-        '@type': '/cosmwasm.wasm.v1.MsgStoreCode',
-        sender,
-        wasm_byte_code,
-        instantiate_permission: instantiate_permission?.toData(),
-      };
-    }
+    return {
+      '@type': '/cosmwasm.wasm.v1.MsgStoreCode',
+      sender,
+      wasm_byte_code,
+      instantiate_permission: instantiate_permission?.toData(),
+    };
   }
 }
 


### PR DESCRIPTION
The so-called "parity upgrade" on Terra Classic is bringing the message format and type URLs of wasmd related messages to parity with Terra. This PR contains:

- Update of all smart contract related messages to ignore `isClassic` flag
- Retain `isClassic` flag for compatibility
- Tested manually with local script
- Remove legacy test case as deprecated

Note, that we did not include updates for the wasm related proposal types, because the governance facilities of wasmd will not be enabled during this upgrade. Please, review and consider to backport it to current release branch of feather.js, so it can be used in station and station-extension. Thank you.