### PR TITLE
feat: Support for JAX MsgExecuteContract and MsgStoreCode.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,9 @@
       "version": "1.0.8",
       "license": "MIT",
       "dependencies": {
+        "@octalmage/terra.proto": "^3.0.5",
         "@terra-money/legacy.proto": "npm:@terra-money/terra.proto@^0.1.7",
-        "@terra-money/terra.proto": "3.0.5",
+        "@terra-money/terra.proto": "^3.0.5",
         "axios": "^0.27.2",
         "bech32": "^2.0.0",
         "bip32": "^2.0.6",
@@ -1189,6 +1190,17 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@octalmage/terra.proto": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@octalmage/terra.proto/-/terra.proto-3.0.5.tgz",
+      "integrity": "sha512-DGMov1K3tasBfJnbxP9N/ELct3M1ZdvG0O+6B5Rdxf4qrYkEIUDzeZdKWQcRplSuCZ3vz3HwvI4qA7LtfNih4Q==",
+      "dependencies": {
+        "@improbable-eng/grpc-web": "^0.14.1",
+        "google-protobuf": "^3.17.3",
+        "long": "^4.0.0",
+        "protobufjs": "~6.11.2"
       }
     },
     "node_modules/@polka/url": {
@@ -8519,6 +8531,17 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
+      }
+    },
+    "@octalmage/terra.proto": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@octalmage/terra.proto/-/terra.proto-3.0.5.tgz",
+      "integrity": "sha512-DGMov1K3tasBfJnbxP9N/ELct3M1ZdvG0O+6B5Rdxf4qrYkEIUDzeZdKWQcRplSuCZ3vz3HwvI4qA7LtfNih4Q==",
+      "requires": {
+        "@improbable-eng/grpc-web": "^0.14.1",
+        "google-protobuf": "^3.17.3",
+        "long": "^4.0.0",
+        "protobufjs": "~6.11.2"
       }
     },
     "@polka/url": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,8 @@
       "version": "1.0.8",
       "license": "MIT",
       "dependencies": {
-        "@octalmage/terra.proto": "^3.0.5",
         "@terra-money/legacy.proto": "npm:@terra-money/terra.proto@^0.1.7",
-        "@terra-money/terra.proto": "^3.0.5",
+        "@terra-money/terra.proto": "^3.1.0-alpha.1",
         "axios": "^0.27.2",
         "bech32": "^2.0.0",
         "bip32": "^2.0.6",
@@ -1192,17 +1191,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@octalmage/terra.proto": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@octalmage/terra.proto/-/terra.proto-3.0.5.tgz",
-      "integrity": "sha512-DGMov1K3tasBfJnbxP9N/ELct3M1ZdvG0O+6B5Rdxf4qrYkEIUDzeZdKWQcRplSuCZ3vz3HwvI4qA7LtfNih4Q==",
-      "dependencies": {
-        "@improbable-eng/grpc-web": "^0.14.1",
-        "google-protobuf": "^3.17.3",
-        "long": "^4.0.0",
-        "protobufjs": "~6.11.2"
-      }
-    },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.21",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
@@ -1293,9 +1281,9 @@
       }
     },
     "node_modules/@terra-money/terra.proto": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@terra-money/terra.proto/-/terra.proto-3.0.5.tgz",
-      "integrity": "sha512-8tvT41qte2mpiNoHq2dMmV7soMxwf4ckuJ+F2pMrb7iVcqaBo30/dIfyTdFm5mEH5i5P6cTJggm+UlIZBSPhwQ==",
+      "version": "3.1.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@terra-money/terra.proto/-/terra.proto-3.1.0-alpha.1.tgz",
+      "integrity": "sha512-aMgfEVqEPh8PUGHM8GVsgVMVLnWHuPHCA+8gfBjZ8vcC0UJYafB6jirRSMd7CRuRbkepE70eRqVt8ip35QBx2A==",
       "dependencies": {
         "@improbable-eng/grpc-web": "^0.14.1",
         "google-protobuf": "^3.17.3",
@@ -8533,17 +8521,6 @@
         "fastq": "^1.6.0"
       }
     },
-    "@octalmage/terra.proto": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@octalmage/terra.proto/-/terra.proto-3.0.5.tgz",
-      "integrity": "sha512-DGMov1K3tasBfJnbxP9N/ELct3M1ZdvG0O+6B5Rdxf4qrYkEIUDzeZdKWQcRplSuCZ3vz3HwvI4qA7LtfNih4Q==",
-      "requires": {
-        "@improbable-eng/grpc-web": "^0.14.1",
-        "google-protobuf": "^3.17.3",
-        "long": "^4.0.0",
-        "protobufjs": "~6.11.2"
-      }
-    },
     "@polka/url": {
       "version": "1.0.0-next.21",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
@@ -8633,9 +8610,9 @@
       }
     },
     "@terra-money/terra.proto": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@terra-money/terra.proto/-/terra.proto-3.0.5.tgz",
-      "integrity": "sha512-8tvT41qte2mpiNoHq2dMmV7soMxwf4ckuJ+F2pMrb7iVcqaBo30/dIfyTdFm5mEH5i5P6cTJggm+UlIZBSPhwQ==",
+      "version": "3.1.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@terra-money/terra.proto/-/terra.proto-3.1.0-alpha.1.tgz",
+      "integrity": "sha512-aMgfEVqEPh8PUGHM8GVsgVMVLnWHuPHCA+8gfBjZ8vcC0UJYafB6jirRSMd7CRuRbkepE70eRqVt8ip35QBx2A==",
       "requires": {
         "@improbable-eng/grpc-web": "^0.14.1",
         "google-protobuf": "^3.17.3",

--- a/package.json
+++ b/package.json
@@ -84,9 +84,8 @@
     "webpack-cli": "^4.3.0"
   },
   "dependencies": {
-    "@octalmage/terra.proto": "^3.0.5",
     "@terra-money/legacy.proto": "npm:@terra-money/terra.proto@^0.1.7",
-    "@terra-money/terra.proto": "^3.0.5",
+    "@terra-money/terra.proto": "^3.1.0-alpha.1",
     "axios": "^0.27.2",
     "bech32": "^2.0.0",
     "bip32": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -84,8 +84,9 @@
     "webpack-cli": "^4.3.0"
   },
   "dependencies": {
+    "@octalmage/terra.proto": "^3.0.5",
     "@terra-money/legacy.proto": "npm:@terra-money/terra.proto@^0.1.7",
-    "@terra-money/terra.proto": "3.0.5",
+    "@terra-money/terra.proto": "^3.0.5",
     "axios": "^0.27.2",
     "bech32": "^2.0.0",
     "bip32": "^2.0.6",

--- a/src/core/Msg.ts
+++ b/src/core/Msg.ts
@@ -58,6 +58,8 @@ import {
   MsgClearContractAdmin,
   WasmMsg,
 } from './wasm/msgs';
+
+import { JAXMsgExecuteContract, JaxExecuteMessage } from './jax/msgs';
 import { MsgTransfer, IbcTransferMsg } from './ibc/applications/transfer';
 import {
   MsgCreateClient,
@@ -112,6 +114,7 @@ export type Msg =
   | CustomMsg
   | MsgLiquidStake
   | MsgRedeemStake
+  | JaxExecuteMessage
   | CrisisMsg;
 
 export namespace Msg {
@@ -127,6 +130,7 @@ export namespace Msg {
     | WasmMsg.Amino
     | IbcTransferMsg.Amino
     | CustomMsg.Amino
+    | JaxExecuteMessage.Amino
     | CrisisMsg.Amino;
 
   export type Data =
@@ -150,6 +154,7 @@ export namespace Msg {
     | CustomMsg.Data
     | MsgLiquidStake.Data
     | MsgRedeemStake.Data
+    | JaxExecuteMessage.Data
     | CrisisMsg.Data;
 
   export type Proto =
@@ -172,10 +177,17 @@ export namespace Msg {
     | AMsgUndelegate.Proto
     | MsgLiquidStake.Proto
     | MsgRedeemStake.Proto
+    | JaxExecuteMessage.Proto
     | CrisisMsg.Proto;
 
   export function fromAmino(data: Msg.Amino, isClassic?: boolean): Msg {
+    console.log(data.type);
     switch (data.type) {
+      case '/jax.MsgExecuteContract':
+        return JAXMsgExecuteContract.fromAmino(
+          data as JAXMsgExecuteContract.Amino,
+          isClassic
+        );
       // bank
       case 'bank/MsgSend':
       case 'cosmos-sdk/MsgSend':
@@ -377,6 +389,7 @@ export namespace Msg {
     }
   }
   export function fromData(data: Msg.Data, isClassic?: boolean): Msg {
+    console.log(data['@type']);
     switch (data['@type']) {
       case '/stride.stakeibc.MsgLiquidStake':
         return MsgLiquidStake.fromData(data, isClassic);
@@ -457,6 +470,9 @@ export namespace Msg {
         return MsgCreateVestingAccount.fromData(data, isClassic);
       case '/cosmos.vesting.v1beta1.MsgDonateAllVestingTokens':
         return MsgDonateAllVestingTokens.fromData(data, isClassic);
+
+      case '/jax.MsgExecuteContract':
+        return JAXMsgExecuteContract.fromData(data, isClassic);
 
       // wasm
       case '/terra.wasm.v1beta1.MsgStoreCode':
@@ -545,7 +561,10 @@ export namespace Msg {
   }
 
   export function fromProto(proto: Any, isClassic?: boolean): Msg {
+    console.log(proto.typeUrl);
     switch (proto.typeUrl) {
+      case '/jax.MsgExecuteContract':
+        return JAXMsgExecuteContract.unpackAny(proto, isClassic);
       case '/stride.stakeibc.MsgLiquidStake':
         return MsgLiquidStake.unpackAny(proto, isClassic);
       case '/stride.stakeibc.MsgRedeemStake':

--- a/src/core/Msg.ts
+++ b/src/core/Msg.ts
@@ -58,8 +58,7 @@ import {
   MsgClearContractAdmin,
   WasmMsg,
 } from './wasm/msgs';
-
-import { JAXMsgExecuteContract, JaxExecuteMessage } from './jax/msgs';
+import { JAXMsgExecuteContract, JAXMsgStoreCode, JaxMsg } from './jax/msgs';
 import { MsgTransfer, IbcTransferMsg } from './ibc/applications/transfer';
 import {
   MsgCreateClient,
@@ -114,8 +113,8 @@ export type Msg =
   | CustomMsg
   | MsgLiquidStake
   | MsgRedeemStake
-  | JaxExecuteMessage
-  | CrisisMsg;
+  | CrisisMsg
+  | JaxMsg;
 
 export namespace Msg {
   export type Amino =
@@ -130,8 +129,8 @@ export namespace Msg {
     | WasmMsg.Amino
     | IbcTransferMsg.Amino
     | CustomMsg.Amino
-    | JaxExecuteMessage.Amino
-    | CrisisMsg.Amino;
+    | CrisisMsg.Amino
+    | JaxMsg.Amino;
 
   export type Data =
     | BankMsg.Data
@@ -154,8 +153,8 @@ export namespace Msg {
     | CustomMsg.Data
     | MsgLiquidStake.Data
     | MsgRedeemStake.Data
-    | JaxExecuteMessage.Data
-    | CrisisMsg.Data;
+    | CrisisMsg.Data
+    | JaxMsg.Data;
 
   export type Proto =
     | BankMsg.Proto
@@ -177,17 +176,11 @@ export namespace Msg {
     | AMsgUndelegate.Proto
     | MsgLiquidStake.Proto
     | MsgRedeemStake.Proto
-    | JaxExecuteMessage.Proto
-    | CrisisMsg.Proto;
+    | CrisisMsg.Proto
+    | JaxMsg.Proto;
 
   export function fromAmino(data: Msg.Amino, isClassic?: boolean): Msg {
-    console.log(data.type);
     switch (data.type) {
-      case '/jax.MsgExecuteContract':
-        return JAXMsgExecuteContract.fromAmino(
-          data as JAXMsgExecuteContract.Amino,
-          isClassic
-        );
       // bank
       case 'bank/MsgSend':
       case 'cosmos-sdk/MsgSend':
@@ -382,6 +375,17 @@ export namespace Msg {
           data as MsgVerifyInvariant.Amino,
           isClassic
         );
+      // jax
+      case 'jax/MsgExecuteContract':
+        return JAXMsgExecuteContract.fromAmino(
+          data as JAXMsgExecuteContract.Amino,
+          isClassic
+        );
+      case 'jax/MsgStoreCode':
+        return JAXMsgStoreCode.fromAmino(
+          data as JAXMsgStoreCode.Amino,
+          isClassic
+        );
 
       // custom
       default:
@@ -389,7 +393,6 @@ export namespace Msg {
     }
   }
   export function fromData(data: Msg.Data, isClassic?: boolean): Msg {
-    console.log(data['@type']);
     switch (data['@type']) {
       case '/stride.stakeibc.MsgLiquidStake':
         return MsgLiquidStake.fromData(data, isClassic);
@@ -471,9 +474,6 @@ export namespace Msg {
       case '/cosmos.vesting.v1beta1.MsgDonateAllVestingTokens':
         return MsgDonateAllVestingTokens.fromData(data, isClassic);
 
-      case '/jax.MsgExecuteContract':
-        return JAXMsgExecuteContract.fromData(data, isClassic);
-
       // wasm
       case '/terra.wasm.v1beta1.MsgStoreCode':
       case '/cosmwasm.wasm.v1.MsgStoreCode':
@@ -554,6 +554,12 @@ export namespace Msg {
       case '/cosmos.crisis.v1beta1.MsgVerifyInvariant':
         return MsgVerifyInvariant.fromData(data, isClassic);
 
+      // jax
+      case '/jax.MsgExecuteContract':
+        return JAXMsgExecuteContract.fromData(data, isClassic);
+      case '/jax.MsgStoreCode':
+        return JAXMsgStoreCode.fromData(data, isClassic);
+
       // custom
       default:
         return MsgAminoCustom.fromData(data, isClassic);
@@ -561,10 +567,7 @@ export namespace Msg {
   }
 
   export function fromProto(proto: Any, isClassic?: boolean): Msg {
-    console.log(proto.typeUrl);
     switch (proto.typeUrl) {
-      case '/jax.MsgExecuteContract':
-        return JAXMsgExecuteContract.unpackAny(proto, isClassic);
       case '/stride.stakeibc.MsgLiquidStake':
         return MsgLiquidStake.unpackAny(proto, isClassic);
       case '/stride.stakeibc.MsgRedeemStake':
@@ -722,6 +725,13 @@ export namespace Msg {
       // crisis
       case '/cosmos.crisis.v1beta1.MsgVerifyInvariant':
         return MsgVerifyInvariant.unpackAny(proto, isClassic);
+
+      // jax
+      case '/jax.MsgExecuteContract':
+        return JAXMsgExecuteContract.unpackAny(proto, isClassic);
+      case '/jax.MsgStoreCode':
+        return JAXMsgStoreCode.unpackAny(proto, isClassic);
+
       default:
         throw Error(`not supported msg ${proto.typeUrl}`);
     }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -27,6 +27,10 @@ export { MsgRedelegate as MsgAllianceRedelegate } from './alliance/msgs/MsgRedel
 export { MsgClaimDelegationRewards as MsgClaimDelegationRewards } from './alliance/msgs/MsgClaimDelegationRewards';
 export * from './alliance/proposals';
 
+// JAX
+export { MsgExecuteContract as JAXMsgExecuteContract } from './jax/msgs/MsgExecuteContract';
+export { MsgStoreCode as JAXMsgStoreCode } from './jax/msgs/MsgStoreCode';
+
 // Auth
 export * from './auth/Account';
 export * from './auth/BaseAccount';

--- a/src/core/jax/msgs/MsgExecuteContract.ts
+++ b/src/core/jax/msgs/MsgExecuteContract.ts
@@ -1,8 +1,8 @@
 import { JSONSerializable, removeNull } from '../../../util/json';
 import { AccAddress } from '../../bech32';
 import { Coins } from '../../Coins';
-import { Any } from '@octalmage/terra.proto/google/protobuf/any';
-import { MsgExecuteContract as MsgExecuteContract_pb } from '@octalmage/terra.proto/jax/tx';
+import { Any } from '@terra-money/terra.proto/google/protobuf/any';
+import { MsgExecuteContract as MsgExecuteContract_pb } from '@terra-money/terra.proto/jax/tx';
 
 export class MsgExecuteContract extends JSONSerializable<
   MsgExecuteContract.Amino,

--- a/src/core/jax/msgs/MsgExecuteContract.ts
+++ b/src/core/jax/msgs/MsgExecuteContract.ts
@@ -54,7 +54,7 @@ export class MsgExecuteContract extends JSONSerializable<
         contract,
         method,
         params,
-        funds: coins.toAmino(),
+        coins: coins.toAmino(),
       },
     };
   }
@@ -139,7 +139,7 @@ export namespace MsgExecuteContract {
       contract: AccAddress;
       method: string;
       params: string;
-      funds: Coins.Amino;
+      coins: Coins.Amino;
     };
   }
 
@@ -160,7 +160,7 @@ export namespace MsgExecuteContract {
     contract: AccAddress;
     method: string;
     params: string;
-    coins: Coins.Amino;
+    coins: Coins.Data;
   }
   export interface DataV2 {
     '@type': '/jax.MsgExecuteContract';
@@ -168,7 +168,7 @@ export namespace MsgExecuteContract {
     contract: AccAddress;
     method: string;
     params: string;
-    coins: Coins.Amino;
+    coins: Coins.Data;
   }
 
   export type Amino = AminoV1 | AminoV2;

--- a/src/core/jax/msgs/MsgExecuteContract.ts
+++ b/src/core/jax/msgs/MsgExecuteContract.ts
@@ -1,0 +1,177 @@
+import { JSONSerializable, removeNull } from '../../../util/json';
+import { AccAddress } from '../../bech32';
+import { Coins } from '../../Coins';
+import { Any } from '@octalmage/terra.proto/google/protobuf/any';
+import { MsgExecuteContract as MsgExecuteContract_pb } from '@octalmage/terra.proto/jax/tx';
+
+export class MsgExecuteContract extends JSONSerializable<
+  MsgExecuteContract.Amino,
+  MsgExecuteContract.Data,
+  MsgExecuteContract.Proto
+> {
+  public coins: Coins;
+
+  /**
+   * @param sender contract user
+   * @param contract contract address
+   * @param method method name on the contract
+   * @param params json stringified params
+   * @param coins coins to be sent to contract
+   */
+  constructor(
+    public sender: AccAddress,
+    public contract: AccAddress,
+    public method: string,
+    public params: string,
+    coins: Coins.Input = {}
+  ) {
+    super();
+    this.coins = new Coins(coins);
+  }
+
+  public static fromAmino(
+    data: MsgExecuteContract.Amino,
+    _?: boolean
+  ): MsgExecuteContract {
+    const {
+      value: { sender, contract, method, params, coins },
+    } = data as MsgExecuteContract.AminoV2;
+    return new MsgExecuteContract(
+      sender,
+      contract,
+      method,
+      params,
+      Coins.fromAmino(coins)
+    );
+  }
+
+  public toAmino(_?: boolean): MsgExecuteContract.Amino {
+    const { sender, contract, method, params, coins } = this;
+    return {
+      type: 'jax/MsgExecuteContract',
+      value: {
+        sender,
+        contract,
+        method,
+        params,
+        funds: coins.toAmino(),
+      },
+    };
+  }
+
+  public static fromProto(
+    proto: MsgExecuteContract.Proto,
+    _?: boolean
+  ): MsgExecuteContract {
+    const p = proto as MsgExecuteContract_pb;
+    return new MsgExecuteContract(
+      p.sender,
+      p.contract,
+      p.method,
+      p.params,
+      Coins.fromProto(p.coins)
+    );
+  }
+
+  public toProto(_?: boolean): MsgExecuteContract.Proto {
+    const { sender, contract, method, params, coins } = this;
+    return MsgExecuteContract_pb.fromPartial({
+      coins: coins.toProto(),
+      contract,
+      sender,
+      method,
+      params,
+    });
+  }
+
+  public packAny(isClassic?: boolean): Any {
+    return Any.fromPartial({
+      typeUrl: '/jax.MsgExecuteContract',
+      value: MsgExecuteContract_pb.encode(
+        this.toProto(isClassic) as MsgExecuteContract_pb
+      ).finish(),
+    });
+  }
+
+  public static unpackAny(
+    msgAny: Any,
+    isClassic?: boolean
+  ): MsgExecuteContract {
+    return MsgExecuteContract.fromProto(
+      MsgExecuteContract_pb.decode(msgAny.value),
+      isClassic
+    );
+  }
+
+  public static fromData(
+    data: MsgExecuteContract.Data,
+    _?: boolean
+  ): MsgExecuteContract {
+    const { sender, contract, method, params, coins } =
+      data as MsgExecuteContract.DataV2;
+    return new MsgExecuteContract(
+      sender,
+      contract,
+      method,
+      params,
+      Coins.fromData(coins)
+    );
+  }
+
+  public toData(_?: boolean): MsgExecuteContract.Data {
+    const { sender, contract, method, params, coins } = this;
+    return {
+      '@type': '/jax.MsgExecuteContract',
+      sender,
+      contract,
+      method,
+      params,
+      coins: coins.toData(),
+    };
+  }
+}
+
+export namespace MsgExecuteContract {
+  export interface AminoV1 {
+    type: 'jax/MsgExecuteContract';
+    value: {
+      sender: AccAddress;
+      contract: AccAddress;
+      method: string;
+      params: string;
+      funds: Coins.Amino;
+    };
+  }
+
+  export interface AminoV2 {
+    type: 'jax/MsgExecuteContract';
+    value: {
+      sender: AccAddress;
+      contract: AccAddress;
+      method: string;
+      params: string;
+      coins: Coins.Amino;
+    };
+  }
+
+  export interface DataV1 {
+    '@type': '/jax.MsgExecuteContract';
+    sender: AccAddress;
+    contract: AccAddress;
+    method: string;
+    params: string;
+    coins: Coins.Amino;
+  }
+  export interface DataV2 {
+    '@type': '/jax.MsgExecuteContract';
+    sender: AccAddress;
+    contract: AccAddress;
+    method: string;
+    params: string;
+    coins: Coins.Amino;
+  }
+
+  export type Amino = AminoV1 | AminoV2;
+  export type Data = DataV1 | DataV2;
+  export type Proto = MsgExecuteContract_pb;
+}

--- a/src/core/jax/msgs/MsgStoreCode.ts
+++ b/src/core/jax/msgs/MsgStoreCode.ts
@@ -1,5 +1,6 @@
 import { JSONSerializable } from '../../../util/json';
 import { AccAddress } from '../../bech32';
+import { Coins } from '../../Coins';
 import { Any } from '@terra-money/terra.proto/google/protobuf/any';
 import { MsgStoreCode as MsgStoreCode_pb } from '@terra-money/terra.proto/jax/tx';
 
@@ -8,19 +9,23 @@ export class MsgStoreCode extends JSONSerializable<
   MsgStoreCode.Data,
   MsgStoreCode.Proto
 > {
+  public coins: Coins;
   /**
    * @param creator contract deployer
    * @param admin address of contract admin, usually contract deployer
    * @param code the JavaScript source code of the contract
    * @param params json stringified params to pass to init
+   * @param coins coins to be sent to contract
    */
   constructor(
     public creator: AccAddress,
     public admin: AccAddress,
     public code: string,
-    public params: string
+    public params: string,
+    coins: Coins.Input = {}
   ) {
     super();
+    this.coins = new Coins(coins);
   }
 
   public static fromAmino(data: MsgStoreCode.Amino, _?: boolean): MsgStoreCode {
@@ -31,7 +36,7 @@ export class MsgStoreCode extends JSONSerializable<
   }
 
   public toAmino(_?: boolean): MsgStoreCode.Amino {
-    const { creator, admin, code, params } = this;
+    const { creator, admin, code, params, coins } = this;
     return {
       type: 'jax/MsgStoreCode',
       value: {
@@ -39,6 +44,7 @@ export class MsgStoreCode extends JSONSerializable<
         admin,
         code,
         params,
+        coins: coins.toAmino(),
       },
     };
   }
@@ -52,12 +58,13 @@ export class MsgStoreCode extends JSONSerializable<
   }
 
   public toProto(_?: boolean): MsgStoreCode.Proto {
-    const { creator, admin, code, params } = this;
+    const { creator, admin, code, params, coins } = this;
     return MsgStoreCode_pb.fromPartial({
       creator,
       admin,
       code,
       params,
+      coins: coins.toProto(),
     });
   }
 
@@ -78,18 +85,25 @@ export class MsgStoreCode extends JSONSerializable<
   }
 
   public static fromData(data: MsgStoreCode.Data, _?: boolean): MsgStoreCode {
-    const { creator, admin, code, params } = data as MsgStoreCode.DataV2;
-    return new MsgStoreCode(creator, admin, code, params);
+    const { creator, admin, code, params, coins } = data as MsgStoreCode.DataV2;
+    return new MsgStoreCode(
+      creator,
+      admin,
+      code,
+      params,
+      Coins.fromData(coins)
+    );
   }
 
   public toData(_?: boolean): MsgStoreCode.Data {
-    const { creator, admin, code, params } = this;
+    const { creator, admin, code, params, coins } = this;
     return {
       '@type': '/jax.MsgStoreCode',
       creator,
       admin,
       code,
       params,
+      coins: coins.toData(),
     };
   }
 }
@@ -102,6 +116,7 @@ export namespace MsgStoreCode {
       admin: AccAddress;
       code: string;
       params: string;
+      coins: Coins.Amino;
     };
   }
 
@@ -112,6 +127,7 @@ export namespace MsgStoreCode {
       admin: AccAddress;
       code: string;
       params: string;
+      coins: Coins.Amino;
     };
   }
 
@@ -121,6 +137,7 @@ export namespace MsgStoreCode {
     admin: AccAddress;
     code: string;
     params: string;
+    coins: Coins.Data;
   }
   export interface DataV2 {
     '@type': '/jax.MsgStoreCode';
@@ -128,6 +145,7 @@ export namespace MsgStoreCode {
     admin: AccAddress;
     code: string;
     params: string;
+    coins: Coins.Data;
   }
 
   export type Amino = AminoV1 | AminoV2;

--- a/src/core/jax/msgs/MsgStoreCode.ts
+++ b/src/core/jax/msgs/MsgStoreCode.ts
@@ -1,0 +1,136 @@
+import { JSONSerializable } from '../../../util/json';
+import { AccAddress } from '../../bech32';
+import { Any } from '@terra-money/terra.proto/google/protobuf/any';
+import { MsgStoreCode as MsgStoreCode_pb } from '@terra-money/terra.proto/jax/tx';
+
+export class MsgStoreCode extends JSONSerializable<
+  MsgStoreCode.Amino,
+  MsgStoreCode.Data,
+  MsgStoreCode.Proto
+> {
+  /**
+   * @param creator contract deployer
+   * @param admin address of contract admin, usually contract deployer
+   * @param code the JavaScript source code of the contract
+   * @param params json stringified params to pass to init
+   */
+  constructor(
+    public creator: AccAddress,
+    public admin: AccAddress,
+    public code: string,
+    public params: string
+  ) {
+    super();
+  }
+
+  public static fromAmino(data: MsgStoreCode.Amino, _?: boolean): MsgStoreCode {
+    const {
+      value: { creator, admin, code, params },
+    } = data as MsgStoreCode.AminoV2;
+    return new MsgStoreCode(creator, admin, code, params);
+  }
+
+  public toAmino(_?: boolean): MsgStoreCode.Amino {
+    const { creator, admin, code, params } = this;
+    return {
+      type: 'jax/MsgStoreCode',
+      value: {
+        creator,
+        admin,
+        code,
+        params,
+      },
+    };
+  }
+
+  public static fromProto(
+    proto: MsgStoreCode.Proto,
+    _?: boolean
+  ): MsgStoreCode {
+    const p = proto as MsgStoreCode_pb;
+    return new MsgStoreCode(p.creator, p.admin, p.code, p.params);
+  }
+
+  public toProto(_?: boolean): MsgStoreCode.Proto {
+    const { creator, admin, code, params } = this;
+    return MsgStoreCode_pb.fromPartial({
+      creator,
+      admin,
+      code,
+      params,
+    });
+  }
+
+  public packAny(isClassic?: boolean): Any {
+    return Any.fromPartial({
+      typeUrl: '/jax.MsgStoreCode',
+      value: MsgStoreCode_pb.encode(
+        this.toProto(isClassic) as MsgStoreCode_pb
+      ).finish(),
+    });
+  }
+
+  public static unpackAny(msgAny: Any, isClassic?: boolean): MsgStoreCode {
+    return MsgStoreCode.fromProto(
+      MsgStoreCode_pb.decode(msgAny.value),
+      isClassic
+    );
+  }
+
+  public static fromData(data: MsgStoreCode.Data, _?: boolean): MsgStoreCode {
+    const { creator, admin, code, params } = data as MsgStoreCode.DataV2;
+    return new MsgStoreCode(creator, admin, code, params);
+  }
+
+  public toData(_?: boolean): MsgStoreCode.Data {
+    const { creator, admin, code, params } = this;
+    return {
+      '@type': '/jax.MsgStoreCode',
+      creator,
+      admin,
+      code,
+      params,
+    };
+  }
+}
+
+export namespace MsgStoreCode {
+  export interface AminoV1 {
+    type: 'jax/MsgStoreCode';
+    value: {
+      creator: AccAddress;
+      admin: AccAddress;
+      code: string;
+      params: string;
+    };
+  }
+
+  export interface AminoV2 {
+    type: 'jax/MsgStoreCode';
+    value: {
+      creator: AccAddress;
+      admin: AccAddress;
+      code: string;
+      params: string;
+    };
+  }
+
+  export interface DataV1 {
+    '@type': '/jax.MsgStoreCode';
+    creator: AccAddress;
+    admin: AccAddress;
+    code: string;
+    params: string;
+  }
+  export interface DataV2 {
+    '@type': '/jax.MsgStoreCode';
+    creator: AccAddress;
+    admin: AccAddress;
+    code: string;
+    params: string;
+  }
+
+  export type Amino = AminoV1 | AminoV2;
+  export type Data = DataV1 | DataV2;
+  export type Proto = MsgStoreCode_pb;
+}

--- a/src/core/jax/msgs/index.ts
+++ b/src/core/jax/msgs/index.ts
@@ -1,0 +1,10 @@
+import { MsgExecuteContract } from './MsgExecuteContract';
+
+export { MsgExecuteContract as JAXMsgExecuteContract };
+
+export type JaxExecuteMessage = MsgExecuteContract;
+export namespace JaxExecuteMessage {
+  export type Data = MsgExecuteContract.Data;
+  export type Amino = MsgExecuteContract.Amino;
+  export type Proto = MsgExecuteContract.Proto;
+}

--- a/src/core/jax/msgs/index.ts
+++ b/src/core/jax/msgs/index.ts
@@ -1,10 +1,16 @@
 import { MsgExecuteContract } from './MsgExecuteContract';
+import { MsgStoreCode } from './MsgStoreCode';
 
+// These messages are similar to the wasm module so prefix with JAX.
 export { MsgExecuteContract as JAXMsgExecuteContract };
+export { MsgStoreCode as JAXMsgStoreCode };
 
-export type JaxExecuteMessage = MsgExecuteContract;
-export namespace JaxExecuteMessage {
-  export type Data = MsgExecuteContract.Data;
-  export type Amino = MsgExecuteContract.Amino;
-  export type Proto = MsgExecuteContract.Proto;
+export type JaxMsg = MsgExecuteContract | MsgStoreCode;
+
+export namespace JaxMsg {
+  export type Data = MsgExecuteContract.Data | MsgStoreCode.Data;
+
+  export type Amino = MsgExecuteContract.Amino | MsgStoreCode.Amino;
+
+  export type Proto = MsgExecuteContract.Proto | MsgStoreCode.Proto;
 }


### PR DESCRIPTION
This PR adds two messages from JAX to Feather.js. 

There's other messages not yet included like updating contracts or changing the contract admin. These will be added at a later point. 