### PR TITLE
feat: upgrade terra.proto and adjust MsgUpdateClient

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@terra-money/feather.js",
-  "version": "1.1.0",
+  "version": "1.1.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@terra-money/feather.js",
-      "version": "1.1.0",
+      "version": "1.1.1-beta.1",
       "license": "MIT",
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@terra-money/legacy.proto": "npm:@terra-money/terra.proto@^0.1.7",
-        "@terra-money/terra.proto": "^4.0.0-beta.3",
+        "@terra-money/terra.proto": "^4.0.1",
         "assert": "^2.0.0",
         "axios": "^0.27.2",
         "bech32": "^2.0.0",
@@ -1999,9 +1999,9 @@
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "node_modules/@terra-money/terra.proto": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@terra-money/terra.proto/-/terra.proto-4.0.0-beta.3.tgz",
-      "integrity": "sha512-bTqdnBxXYg/8rm8eYH4hQLQuOzBWtXO4HZrcKqzRchdoKOPKBDZnFbTBhGZOwzT4ZgJswO3ge85EUYD6MdIY4w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@terra-money/terra.proto/-/terra.proto-4.0.1.tgz",
+      "integrity": "sha512-P9JcI+rxEIxhQ7l0Jb9aN+luApuJHI13M15Ns6uuVX99V3u7Qwb+0EGD9CjNNDPPVgqZA2ctm1/KVEFXTqqZSA==",
       "dependencies": {
         "@improbable-eng/grpc-web": "^0.14.1",
         "browser-headers": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/feather.js",
-  "version": "1.1.0",
+  "version": "1.1.1-beta.1",
   "description": "The JavaScript SDK for Terra and Feather chains",
   "license": "MIT",
   "author": "Terraform Labs, PTE.",
@@ -87,7 +87,7 @@
   "dependencies": {
     "@ethersproject/bytes": "^5.7.0",
     "@terra-money/legacy.proto": "npm:@terra-money/terra.proto@^0.1.7",
-    "@terra-money/terra.proto": "^4.0.0-beta.3",
+    "@terra-money/terra.proto": "^4.0.1",
     "assert": "^2.0.0",
     "axios": "^0.27.2",
     "bech32": "^2.0.0",

--- a/src/core/ibc/msgs/client/MsgUpdateClient.ts
+++ b/src/core/ibc/msgs/client/MsgUpdateClient.ts
@@ -2,7 +2,6 @@ import { JSONSerializable } from '../../../../util/json';
 import { AccAddress } from '../../../bech32';
 import { Any } from '@terra-money/terra.proto/google/protobuf/any';
 import { MsgUpdateClient as MsgUpdateClient_pb } from '@terra-money/terra.proto/ibc/core/client/v1/tx';
-import { Header } from '../../lightclient/tendermint/Header';
 /**
  * MsgUpdateClient defines an sdk.Msg to update a IBC client state using the given header
  */
@@ -18,7 +17,7 @@ export class MsgUpdateClient extends JSONSerializable<
    */
   constructor(
     public client_id: string,
-    public header: Header | undefined,
+    public clientMessage: Any | undefined,
     public signer: string
   ) {
     super();
@@ -39,21 +38,17 @@ export class MsgUpdateClient extends JSONSerializable<
     _?: boolean
   ): MsgUpdateClient {
     _;
-    const { client_id, header, signer } = data;
-    return new MsgUpdateClient(
-      client_id,
-      header ? Header.fromData(header) : undefined,
-      signer
-    );
+    const { client_id, clientMessage, signer } = data;
+    return new MsgUpdateClient(client_id, clientMessage, signer);
   }
 
   public toData(_?: boolean): MsgUpdateClient.Data {
     _;
-    const { client_id, header, signer } = this;
+    const { client_id, clientMessage, signer } = this;
     return {
       '@type': '/ibc.core.client.v1.MsgUpdateClient',
       client_id,
-      header: header?.toData() || undefined,
+      clientMessage,
       signer,
     };
   }
@@ -65,17 +60,17 @@ export class MsgUpdateClient extends JSONSerializable<
     _;
     return new MsgUpdateClient(
       proto.clientId,
-      proto.header ? Header.unpackAny(proto.header) : undefined,
+      proto.clientMessage,
       proto.signer
     );
   }
 
   public toProto(_?: boolean): MsgUpdateClient.Proto {
     _;
-    const { client_id, header, signer } = this;
+    const { client_id, clientMessage, signer } = this;
     return MsgUpdateClient_pb.fromPartial({
       clientId: client_id,
-      header: header?.packAny() || undefined,
+      clientMessage: clientMessage,
       signer,
     });
   }
@@ -98,7 +93,7 @@ export namespace MsgUpdateClient {
   export interface Data {
     '@type': '/ibc.core.client.v1.MsgUpdateClient';
     client_id: string;
-    header?: Header.Data;
+    clientMessage?: Any;
     signer: AccAddress;
   }
   export type Proto = MsgUpdateClient_pb;


### PR DESCRIPTION
[@terra-money/feather.js@1.1.1-beta.1](https://www.npmjs.com/package/@terra-money/feather.js/v/1.1.1-beta.1) with fixed IBC models for MsgUpdateClient and all new proto models compatible with Core v2.5.