### PR TITLE
feat: instantiate default empty

### DIFF
--- a/src/core/wasm/msgs/MsgInstantiateContract.ts
+++ b/src/core/wasm/msgs/MsgInstantiateContract.ts
@@ -27,7 +27,7 @@ export class MsgInstantiateContract extends JSONSerializable<
     public code_id: number,
     public init_msg: object | string,
     init_coins: Coins.Input = {},
-    public label?: string
+    public label: string = '-'
   ) {
     super();
     this.init_coins = new Coins(init_coins);


### PR DESCRIPTION
Defaults the label as "-" since empty string or undefined is not allowed and developers may not want to use a label