### PR TITLE
fix: alliance delegation model does not need to be coins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@terra-money/feather.js",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@terra-money/feather.js",
-      "version": "3.0.0-beta.1",
+      "version": "3.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@terra-money/legacy.proto": "npm:@terra-money/terra.proto@^0.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@terra-money/feather.js",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@terra-money/feather.js",
-      "version": "3.0.0-beta.2",
+      "version": "3.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "@terra-money/legacy.proto": "npm:@terra-money/terra.proto@^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/feather.js",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0-beta.3",
   "description": "The JavaScript SDK for Terra and Feather chains",
   "license": "MIT",
   "author": "Terraform Labs, PTE.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/feather.js",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-beta.2",
   "description": "The JavaScript SDK for Terra and Feather chains",
   "license": "MIT",
   "author": "Terraform Labs, PTE.",

--- a/src/client/lcd/api/AllianceAPI.ts
+++ b/src/client/lcd/api/AllianceAPI.ts
@@ -7,7 +7,7 @@ import {
   AllianceUnbonding,
   AllianceValidator,
 } from '../../../core/alliance';
-import { AccAddress, Coins, ValAddress } from '../../../core';
+import { AccAddress, Coins, Coin, ValAddress } from '../../../core';
 import { APIParams, Pagination, PaginationOptions } from '../APIRequester';
 import { LCDClient } from '../LCDClient';
 
@@ -108,7 +108,7 @@ export class AllianceAPI extends BaseAPI {
     params: Partial<PaginationOptions & APIParams> = {}
   ): Promise<{
     delegations: AllianceDelegation[];
-    balance: Coins;
+    balance: Coin;
     pagination: Pagination;
   }> {
     let url = `/terra/alliances/delegations`;
@@ -138,7 +138,7 @@ export class AllianceAPI extends BaseAPI {
     if (delAddr && valAddr && denom) {
       const res = await this.getReqFromChainID(chainID).get<{
         delegation: AllianceDelegation.Data;
-        balance: Coins.Data;
+        balance: Coin.Data;
       }>(url, params);
 
       return {
@@ -147,19 +147,19 @@ export class AllianceAPI extends BaseAPI {
           total: 1,
         },
         delegations: [AllianceDelegation.fromData(res.delegation)],
-        balance: Coins.fromData(res.balance),
+        balance: Coin.fromData(res.balance),
       };
     } else {
       const res = await this.getReqFromChainID(chainID).get<{
         delegations: AllianceDelegation.Data[];
-        balance: Coins.Data;
+        balance: Coin.Data;
         pagination: Pagination;
       }>(url, params);
 
       return {
         pagination: res.pagination,
         delegations: res.delegations.map(d => AllianceDelegation.fromData(d)),
-        balance: Coins.fromData(res.balance),
+        balance: Coin.fromData(res.balance),
       };
     }
   }

--- a/src/client/lcd/api/AllianceAPI.ts
+++ b/src/client/lcd/api/AllianceAPI.ts
@@ -108,7 +108,6 @@ export class AllianceAPI extends BaseAPI {
     params: Partial<PaginationOptions & APIParams> = {}
   ): Promise<{
     delegations: AllianceDelegation[];
-    balance: Coin;
     pagination: Pagination;
   }> {
     let url = `/terra/alliances/delegations`;
@@ -138,7 +137,6 @@ export class AllianceAPI extends BaseAPI {
     if (delAddr && valAddr && denom) {
       const res = await this.getReqFromChainID(chainID).get<{
         delegation: AllianceDelegation.Data;
-        balance: Coin.Data;
       }>(url, params);
 
       return {
@@ -147,7 +145,6 @@ export class AllianceAPI extends BaseAPI {
           total: 1,
         },
         delegations: [AllianceDelegation.fromData(res.delegation)],
-        balance: Coin.fromData(res.balance),
       };
     } else {
       const res = await this.getReqFromChainID(chainID).get<{
@@ -159,7 +156,6 @@ export class AllianceAPI extends BaseAPI {
       return {
         pagination: res.pagination,
         delegations: res.delegations.map(d => AllianceDelegation.fromData(d)),
-        balance: Coin.fromData(res.balance),
       };
     }
   }

--- a/src/client/lcd/api/ICAv1API.ts
+++ b/src/client/lcd/api/ICAv1API.ts
@@ -4,7 +4,7 @@ import { QueryInterchainAccountResponse } from '@terra-money/terra.proto/ibc/app
 import { APIParams } from '../APIRequester';
 import { LCDClient } from '../LCDClient';
 import { BaseAPI } from './BaseAPI';
-import { AccAddress } from 'core';
+import { AccAddress } from '../../../core';
 
 export class ICAv1API extends BaseAPI {
   constructor(public lcd: LCDClient) {

--- a/src/core/alliance/models/AllianceDelegation.ts
+++ b/src/core/alliance/models/AllianceDelegation.ts
@@ -1,5 +1,5 @@
 import { Dec } from '../../../core/numeric';
-import { AccAddress, ValAddress } from 'core/bech32';
+import { AccAddress, ValAddress } from '../../../core/bech32';
 import { RewardHistory } from './RewardHistory';
 import Long from 'long';
 import { Coin } from '../../../core/Coin';

--- a/src/core/alliance/models/AllianceDelegation.ts
+++ b/src/core/alliance/models/AllianceDelegation.ts
@@ -15,7 +15,8 @@ export class AllianceDelegation {
     /** shares define the Alliancedelegation shares received. */
     public shares: Dec,
     public rewardHistory: RewardHistory[],
-    public lastRewardClaimHeight: Long
+    public lastRewardClaimHeight: Long,
+    public balance: Coin
   ) {}
 
   public static fromData(
@@ -24,12 +25,15 @@ export class AllianceDelegation {
   ): AllianceDelegation {
     _;
     const {
-      delegator_address,
-      validator_address,
-      denom,
-      shares,
-      reward_history,
-      last_reward_claim_height,
+      delegation: {
+        delegator_address,
+        validator_address,
+        denom,
+        shares,
+        reward_history,
+        last_reward_claim_height,
+      },
+      balance,
     } = data;
 
     return new AllianceDelegation(
@@ -38,7 +42,8 @@ export class AllianceDelegation {
       denom,
       new Dec(shares),
       reward_history?.map(r => RewardHistory.fromData(r)),
-      last_reward_claim_height
+      last_reward_claim_height,
+      Coin.fromData(balance)
     );
   }
 
@@ -51,30 +56,37 @@ export class AllianceDelegation {
       shares,
       rewardHistory,
       lastRewardClaimHeight,
+      balance,
     } = this;
 
     return {
-      delegator_address: delegatorAddress,
-      validator_address: validatorAddress,
-      denom: denom,
-      shares: shares.toString(),
-      reward_history: rewardHistory,
-      last_reward_claim_height: lastRewardClaimHeight,
+      delegation: {
+        delegator_address: delegatorAddress,
+        validator_address: validatorAddress,
+        denom: denom,
+        shares: shares.toString(),
+        reward_history: rewardHistory,
+        last_reward_claim_height: lastRewardClaimHeight,
+      },
+      balance: balance.toData(),
     };
   }
 }
 
 export namespace AllianceDelegation {
   export interface Data {
-    /** delegator_address is the bech32-encoded address of the delegator. */
-    delegator_address: AccAddress;
-    /** validator_address is the bech32-encoded address of the validator. */
-    validator_address: ValAddress;
-    /** denom of token staked */
-    denom: string;
-    /** shares define the Alliancedelegation shares received. */
-    shares: string;
-    reward_history: RewardHistory.Data[];
-    last_reward_claim_height: Long;
+    delegation: {
+      /** delegator_address is the bech32-encoded address of the delegator. */
+      delegator_address: AccAddress;
+      /** validator_address is the bech32-encoded address of the validator. */
+      validator_address: ValAddress;
+      /** denom of token staked */
+      denom: string;
+      /** shares define the Alliancedelegation shares received. */
+      shares: string;
+      reward_history: RewardHistory.Data[];
+      last_reward_claim_height: Long;
+    };
+    balance: Coin.Data;
   }
 }

--- a/src/core/alliance/models/AllianceRedelegation.ts
+++ b/src/core/alliance/models/AllianceRedelegation.ts
@@ -1,4 +1,4 @@
-import { AccAddress, ValAddress } from 'core/bech32';
+import { AccAddress, ValAddress } from '../../../core/bech32';
 import { Coin } from '../../../core/Coin';
 
 export class AllianceRedelegation {

--- a/src/core/alliance/models/AllianceUnbondings.ts
+++ b/src/core/alliance/models/AllianceUnbondings.ts
@@ -1,4 +1,4 @@
-import { ValAddress } from 'core/bech32';
+import { ValAddress } from '../../../core/bech32';
 
 export class AllianceUnbonding {
   constructor(

--- a/src/core/alliance/models/AllianceValidator.ts
+++ b/src/core/alliance/models/AllianceValidator.ts
@@ -1,5 +1,4 @@
-import { ValAddress } from 'core/bech32';
-import { Coin } from '../../../core/Coin';
+import { ValAddress } from '../../../core/bech32';
 import { AllianceValidatorAmount } from './AllianceValidatorAmount';
 
 export class AllianceValidator {

--- a/src/core/feemarket/v1/models/FeemarketDenomParams.ts
+++ b/src/core/feemarket/v1/models/FeemarketDenomParams.ts
@@ -1,5 +1,5 @@
 import { FeeDenomParam as FeeDenomParam_pb } from '@terra-money/terra.proto/feemarket/feemarket/v1/genesis';
-import { Denom } from 'core/Denom';
+import { Denom } from '../../../../core/Denom';
 import Decimal from 'decimal.js';
 import { JSONSerializable } from '../../../../util/json';
 

--- a/src/core/gov/v1/Proposal.ts
+++ b/src/core/gov/v1/Proposal.ts
@@ -43,7 +43,7 @@ import {
   MsgFeeDenomParam,
   MsgRemoveFeeDenomParam,
 } from '../../../core/feemarket';
-import { AccAddress } from 'core/bech32';
+import { AccAddress } from '../../../core/bech32';
 
 /**
  * Stores information pertaining to a submitted proposal, such as its status and time of


### PR DESCRIPTION
Fix a typo that transformed the delegated balance to Coins when in fact they are Coin. This needs to be fixed because it can mislead developers into thinking that the delegations are accumulated into multiple coins 